### PR TITLE
fix datetime format: en localization format time 12:00 to 00:00

### DIFF
--- a/src/views/bill/_form.php
+++ b/src/views/bill/_form.php
@@ -93,7 +93,7 @@ $form = ActiveForm::begin([
                             'type' => DatePicker::TYPE_COMPONENT_APPEND,
                             'pluginOptions' => [
                                 'autoclose' => true,
-                                'format' => 'dd.mm.yyyy HH:ii:ss',
+                                'format' => 'dd.mm.yyyy hh:ii:ss',
                             ],
                             'options' => [
                                 'value' => Yii::$app->formatter->asDatetime(($model->isNewRecord ? new DateTime() : $model->time), 'php:d.m.Y H:i:s'),


### PR DESCRIPTION
В англиской локализации время неправильно трансформировалось (нельзя было прописать время от 12:00 до 00:00)