### PR TITLE
Deleted copy button from tariff plan view page

### DIFF
--- a/src/menus/PlanDetailMenu.php
+++ b/src/menus/PlanDetailMenu.php
@@ -27,7 +27,8 @@ class PlanDetailMenu extends \hipanel\menus\AbstractDetailMenu
                     'handleSubmit' => false,
                 ]),
                 'encode' => false,
-                'visible' => !$this->model->isDeleted() && Yii::$app->user->can('plan.create'),
+//                'visible' => !$this->model->isDeleted() && Yii::$app->user->can('plan.create'),
+                'visible' => false,
             ],
             'delete' => [
                 'label' => Yii::t('hipanel', 'Delete'),


### PR DESCRIPTION
It was done because copying of the tariff plans isn't implemented
in hiapi yet.