### PR TITLE
 ImportPayments: corrected test

### DIFF
--- a/tests/acceptance/manager/ImportPaymentsCest.php
+++ b/tests/acceptance/manager/ImportPaymentsCest.php
@@ -67,11 +67,11 @@ class ImportPaymentsCest
         return [
             'importData' => [
                 'client'      => 'hipanel_test_user',
-                'time'        => date('h:i:s'),
+                'time'        => strftime("%l:%M:%S"),
                 'amount'      => 300,
                 'currency'    => 'USD',
                 'type'        => 'PayPal',
-                'description' => null,
+                'description' => 'description' . uniqid(),
             ],
         ];
     }


### PR DESCRIPTION
На description ранье был баг, потом его пофиксили, ну и я добавил. 
А по времени - раньше выдавало 08:00:00, а теперь 8:00:00, без ведущего пробела. (так отображается во вьюхе)