### PR TITLE
HP-1869: show last doc numbers; select document type before reservation

### DIFF
--- a/src/grid/RequisiteGridView.php
+++ b/src/grid/RequisiteGridView.php
@@ -130,6 +130,22 @@ class RequisiteGridView extends ContactGridView
             'templates' => [
                 'class' => RequisiteTemplateColumn::class,
             ],
+            'last_no' => [
+                'label' => Yii::t('hipanel:finance', 'Last numbers'),
+                'format' => 'raw',
+                'filter' => false,
+                'value' => function (Requisite $model) {
+                    $value = '';
+                    foreach (['invoice_last_no', 'sinvoice_last_no', 'pinvoice_last_no', 'proforma_last_no', 'sproforma_last_no', 'pproforma_last_no'] as $attr) {
+                        if (empty($model->$attr)) {
+                            continue;
+                        }
+                        $value .= Html::tag('p', Html::tag("b", "{$model->getAttributeLabel($attr)}: ") . ($model->$attr ?? ''));
+                    }
+
+                    return $value;
+                }
+            ],
         ], $curColumns ?? [],
             $balanceColumns ?? []
         );

--- a/src/grid/RequisiteRepresentations.php
+++ b/src/grid/RequisiteRepresentations.php
@@ -23,7 +23,7 @@ class RequisiteRepresentations extends RepresentationCollection
                 'columns' => array_filter([
                     'checkbox',
                     'client_like',
-                    'name', 'actions', 'serie', 'requisites', 'templates'
+                    'name', 'actions', 'serie', 'requisites', 'templates', 'last_no',
                 ]),
             ],
             'balances' => [

--- a/src/messages/ru/hipanel:finance.php
+++ b/src/messages/ru/hipanel:finance.php
@@ -316,4 +316,5 @@ return [
     'Calculate costprice' => 'Расчитать costprice',
     'Finance tools' => 'Финансовые инструменты',
     'Process' => 'Процесс',
+    'Last numbers' => 'Последние номера',
 ];

--- a/src/views/purse/_client-view.php
+++ b/src/views/purse/_client-view.php
@@ -44,7 +44,7 @@ if ($user->can('document.read') && $user->can('bill.read')) {
                 $user->can('document.read') && $isEmployee ? 'ndas' : null,
                 $user->can('document.read') && $isEmployee ? 'internalinvoices' : null,
                 $user->can('owner-staff') && $user->can('document.read') && !$isEmployee ? 'invoices' : null,
-                $user->can('owner-staff') && $user->can('document.read') && !$isEmployee ? 'iproformaInvoices' : null,
+                $user->can('owner-staff') && $user->can('document.read') && !$isEmployee ? 'proformaInvoices' : null,
             ], $documents)),
         ]) ?>
     <?php $box->endBody() ?>

--- a/src/views/purse/_client-view.php
+++ b/src/views/purse/_client-view.php
@@ -16,7 +16,7 @@ $documentType = $isEmployee ? 'acceptance' : 'invoice';
 
 $documents = [];
 if ($user->can('document.read') && $user->can('bill.read')) {
-    $documents = ($isEmployee ? ['acceptances'] : ['invoices', 'serviceInvoices', 'purchaseInvoices', 'proformaInvoices', 'serviceProformas', 'purchaseProformas']);
+    $documents = ($isEmployee ? ['acceptances'] : ['serviceInvoices', 'purchaseInvoices', 'serviceProformas', 'purchaseProformas']);
 }
 
 ?>
@@ -43,6 +43,8 @@ if ($user->can('document.read') && $user->can('bill.read')) {
                 $user->can('document.read') && $isEmployee ? 'probations' : null,
                 $user->can('document.read') && $isEmployee ? 'ndas' : null,
                 $user->can('document.read') && $isEmployee ? 'internalinvoices' : null,
+                $user->can('owner-staff') && $user->can('document.read') && !$isEmployee ? 'invoices' : null,
+                $user->can('owner-staff') && $user->can('document.read') && !$isEmployee ? 'iproformaInvoices' : null,
             ], $documents)),
         ]) ?>
     <?php $box->endBody() ?>

--- a/src/views/requisite/modal/reserveNumber.php
+++ b/src/views/requisite/modal/reserveNumber.php
@@ -3,6 +3,7 @@
 use hipanel\helpers\Url;
 use hipanel\modules\client\widgets\combo\ClientCombo;
 use hipanel\modules\client\widgets\combo\ContactCombo;
+use hipanel\modules\document\widgets\combo\FinancialDocumentTypeCombo;
 use yii\helpers\Html;
 use yii\bootstrap\ActiveForm;
 
@@ -27,6 +28,7 @@ $this->params['breadcrumbs'][] = $this->title;
     <?= $form->field($model, 'id')->hiddenInput()->label(false); ?>
     <?= $form->field($model, 'client_id')->widget(ClientCombo::class) ?>
     <?= $form->field($model, 'recipient_id')->widget(ContactCombo::class) ?>
+    <?= $form->field($model, 'type')->widget(FinancialDocumentTypeCombo::class) ?>
     <?= Html::submitButton(Yii::t('hipanel', 'Save'), ['class' => 'btn btn-success']) ?>
 
 <?php $form->end() ?>

--- a/src/views/requisite/view.php
+++ b/src/views/requisite/view.php
@@ -92,7 +92,10 @@ FlagIconCssAsset::register($this);
                             'boxed'   => false,
                             'model'   => $model,
                             'columns' => [
-                                'reg_data', 'vat_rate', 'invoice_last_no',
+                                'reg_data', 'vat_rate',
+                                'invoice_last_no', 'proforma_last_no',
+                                'sinvoice_last_no', 'sproforma_last_no',
+                                'pinvoice_last_no', 'pproforma_last_no',
                                 'serie', 'registration_number', 'tic',
                             ],
                         ]) ?>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new column to display various last numbers related to requisites in grid views.
	- Introduced a new translation for "Last numbers" in the finance section.
	- Enhanced user permission checks for document array population in client views.
	- Utilized `FinancialDocumentTypeCombo` widget in the reserve number form for better user interaction.
	- Expanded requisite view components to include additional invoice and series fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->