### PR TITLE
HP-1783: rename-proforma-to-payment-request

### DIFF
--- a/src/grid/PurseGridView.php
+++ b/src/grid/PurseGridView.php
@@ -42,11 +42,11 @@ class PurseGridView extends BoxedGridView
                 'class' => MonthlyDocumentsColumn::class,
                 'type' => 'payment_request',
             ],
-            'serviceProformas' => [
+            'servicePaymentRequests' => [
                 'class' => MonthlyDocumentsColumn::class,
                 'type' => 'service_payment_request',
             ],
-            'purchaseProformas' => [
+            'purchasePaymentRequests' => [
                 'class' => MonthlyDocumentsColumn::class,
                 'type' => 'purchase_payment_request',
             ],

--- a/src/grid/PurseGridView.php
+++ b/src/grid/PurseGridView.php
@@ -38,17 +38,17 @@ class PurseGridView extends BoxedGridView
                 'class' => MonthlyDocumentsColumn::class,
                 'type' => 'purchase_invoice',
             ],
-            'proformaInvoices' => [
+            'payment_requestInvoices' => [
                 'class' => MonthlyDocumentsColumn::class,
-                'type' => 'proforma',
+                'type' => 'payment_request',
             ],
             'serviceProformas' => [
                 'class' => MonthlyDocumentsColumn::class,
-                'type' => 'service_proforma',
+                'type' => 'service_payment_request',
             ],
             'purchaseProformas' => [
                 'class' => MonthlyDocumentsColumn::class,
-                'type' => 'purchase_proforma',
+                'type' => 'purchase_payment_request',
             ],
             'acceptances' => [
                 'class' => MonthlyDocumentsColumn::class,

--- a/src/grid/RequisiteGridView.php
+++ b/src/grid/RequisiteGridView.php
@@ -136,7 +136,7 @@ class RequisiteGridView extends ContactGridView
                 'filter' => false,
                 'value' => function (Requisite $model) {
                     $value = '';
-                    foreach (['invoice_last_no', 'sinvoice_last_no', 'pinvoice_last_no', 'proforma_last_no', 'sproforma_last_no', 'pproforma_last_no'] as $attr) {
+                    foreach (['invoice_last_no', 'sinvoice_last_no', 'pinvoice_last_no', 'payment_request_last_no', 'spayment_request_last_no', 'ppayment_request_last_no'] as $attr) {
                         if (empty($model->$attr)) {
                             continue;
                         }

--- a/src/models/Purse.php
+++ b/src/models/Purse.php
@@ -121,17 +121,17 @@ class Purse extends \hipanel\base\Model
 
     public function getProformaInvoices()
     {
-        return $this->getDocumentsOfType('proforma');
+        return $this->getDocumentsOfType('payment_request');
     }
 
     public function getPurchaseProformas(): array
     {
-        return $this->getDocumentsOfType('purchase_proforma');
+        return $this->getDocumentsOfType('purchase_payment_request');
     }
 
     public function getServiceProformas(): array
     {
-        return $this->getDocumentsOfType('service_proforma');
+        return $this->getDocumentsOfType('service_payment_request');
     }
 
     public function getDocumentsOfType($type): array
@@ -176,7 +176,7 @@ class Purse extends \hipanel\base\Model
             'invoices' => Yii::t('hipanel:finance', 'Invoices'),
             'serviceInvoices' => Yii::t('hipanel:finance', 'Service Invoices'),
             'purchaseInvoices' => Yii::t('hipanel:finance', 'Purchase Invoices'),
-            'proformaInvoices' => Yii::t('hipanel:finance', 'Payment Request'),
+            'payment_requestInvoices' => Yii::t('hipanel:finance', 'Payment Request'),
             'purchaseProformas' => Yii::t('hipanel:finance', 'Purchase Payment Request'),
             'serviceProformas' => Yii::t('hipanel:finance', 'Service Payment Request'),
             'acceptances' => Yii::t('hipanel:finance', 'Acceptance reports'),

--- a/src/models/Purse.php
+++ b/src/models/Purse.php
@@ -119,17 +119,17 @@ class Purse extends \hipanel\base\Model
         return $this->getDocumentsOfType('internal_invoice');
     }
 
-    public function getProformaInvoices()
+    public function getPaymentRequestInvoices()
     {
         return $this->getDocumentsOfType('payment_request');
     }
 
-    public function getPurchaseProformas(): array
+    public function getPurchasePaymentRequests(): array
     {
         return $this->getDocumentsOfType('purchase_payment_request');
     }
 
-    public function getServiceProformas(): array
+    public function getServicePaymentRequests(): array
     {
         return $this->getDocumentsOfType('service_payment_request');
     }
@@ -177,8 +177,8 @@ class Purse extends \hipanel\base\Model
             'serviceInvoices' => Yii::t('hipanel:finance', 'Service Invoices'),
             'purchaseInvoices' => Yii::t('hipanel:finance', 'Purchase Invoices'),
             'payment_requestInvoices' => Yii::t('hipanel:finance', 'Payment Request'),
-            'purchaseProformas' => Yii::t('hipanel:finance', 'Purchase Payment Request'),
-            'serviceProformas' => Yii::t('hipanel:finance', 'Service Payment Request'),
+            'purchasePaymentRequests' => Yii::t('hipanel:finance', 'Purchase Payment Request'),
+            'servicePaymentRequests' => Yii::t('hipanel:finance', 'Service Payment Request'),
             'acceptances' => Yii::t('hipanel:finance', 'Acceptance reports'),
             'contracts' => Yii::t('hipanel:finance', 'Contracts'),
             'probations' => Yii::t('hipanel:finance', 'Probation'),

--- a/src/models/Requisite.php
+++ b/src/models/Requisite.php
@@ -29,11 +29,11 @@ class Requisite extends Contact
     const TEMPLATE_CONTRACT = 'contract';
     const TEMPLATE_PROBATION = 'probation';
     const TEMPLATE_INTERNAL_INVOICE = 'internal_invoice';
-    const TEMPLATE_PROFORMA = 'proforma';
+    const TEMPLATE_PROFORMA = 'payment_request';
     const TEMPLATE_PURCHASE_INVOICE = 'purchase_invoice';
     const TEMPLATE_SERVICE_INVOICE = 'service_invoice';
     const TEMPLATE_PURCHASE_PROFORMA = 'purchase_invoice';
-    const TEMPLATE_SERVICE_PROFORMA = 'service_proforma';
+    const TEMPLATE_SERVICE_PROFORMA = 'service_payment_request';
 
     public static function tableName()
     {
@@ -58,7 +58,7 @@ class Requisite extends Contact
                     'contract_id',
                     'probation_id',
                     'internal_invoice_id',
-                    'proforma_id',
+                    'payment_request_id',
                     'nda_id',
                 ],
                 'string', // template2pdf ID
@@ -72,9 +72,9 @@ class Requisite extends Contact
                     'internal_invoice_name',
                     'purchase_invoice_name',
                     'service_invoice_name',
-                    'purchase_proforma_name',
-                    'service_proforma_name',
-                    'proforma_name',
+                    'purchase_payment_request_name',
+                    'service_payment_request_name',
+                    'payment_request_name',
                     'nda_name',
                 ],
                 'string',
@@ -123,7 +123,7 @@ class Requisite extends Contact
             'acceptance_name' => Yii::t('hipanel:finance', 'Acceptance template'),
             'contract_name' => Yii::t('hipanel:finance', 'Contract template'),
             'probation_name' => Yii::t('hipanel:finance', 'Probation template'),
-            'proforma_name' => Yii::t('hipanel:finance', 'Proforma template'),
+            'payment_request_name' => Yii::t('hipanel:finance', 'Proforma template'),
             'recipient_id' => Yii::t('hipanel:finance', 'Recipient'),
             'balance' => Yii::t('hipanel:finance', 'Balance'),
         ]);

--- a/src/models/Requisite.php
+++ b/src/models/Requisite.php
@@ -29,11 +29,11 @@ class Requisite extends Contact
     const TEMPLATE_CONTRACT = 'contract';
     const TEMPLATE_PROBATION = 'probation';
     const TEMPLATE_INTERNAL_INVOICE = 'internal_invoice';
-    const TEMPLATE_PROFORMA = 'payment_request';
+    const TEMPLATE_PAYMENT_REQUEST = 'payment_request';
     const TEMPLATE_PURCHASE_INVOICE = 'purchase_invoice';
     const TEMPLATE_SERVICE_INVOICE = 'service_invoice';
-    const TEMPLATE_PURCHASE_PROFORMA = 'purchase_invoice';
-    const TEMPLATE_SERVICE_PROFORMA = 'service_payment_request';
+    const TEMPLATE_PURCHASE_PAYMENT_REQUEST = 'purchase_invoice';
+    const TEMPLATE_SERVICE_PAYMENT_REQUEST = 'service_payment_request';
 
     public static function tableName()
     {
@@ -137,7 +137,7 @@ class Requisite extends Contact
             self::TEMPLATE_CONTRACT => self::TEMPLATE_CONTRACT,
             self::TEMPLATE_PROBATION => self::TEMPLATE_PROBATION,
             self::TEMPLATE_INTERNAL_INVOICE => self::TEMPLATE_INTERNAL_INVOICE,
-            self::TEMPLATE_PROFORMA => self::TEMPLATE_PROFORMA,
+            self::TEMPLATE_PAYMENT_REQUEST => self::TEMPLATE_PAYMENT_REQUEST,
         ];
     }
 

--- a/src/models/Requisite.php
+++ b/src/models/Requisite.php
@@ -123,7 +123,7 @@ class Requisite extends Contact
             'acceptance_name' => Yii::t('hipanel:finance', 'Acceptance template'),
             'contract_name' => Yii::t('hipanel:finance', 'Contract template'),
             'probation_name' => Yii::t('hipanel:finance', 'Probation template'),
-            'payment_request_name' => Yii::t('hipanel:finance', 'Proforma template'),
+            'payment_request_name' => Yii::t('hipanel:finance', 'Payment request template'),
             'recipient_id' => Yii::t('hipanel:finance', 'Recipient'),
             'balance' => Yii::t('hipanel:finance', 'Balance'),
         ]);

--- a/src/models/Requisite.php
+++ b/src/models/Requisite.php
@@ -32,7 +32,7 @@ class Requisite extends Contact
     const TEMPLATE_PAYMENT_REQUEST = 'payment_request';
     const TEMPLATE_PURCHASE_INVOICE = 'purchase_invoice';
     const TEMPLATE_SERVICE_INVOICE = 'service_invoice';
-    const TEMPLATE_PURCHASE_PAYMENT_REQUEST = 'purchase_invoice';
+    const TEMPLATE_PURCHASE_PAYMENT_REQUEST = 'purchase_payment_request';
     const TEMPLATE_SERVICE_PAYMENT_REQUEST = 'service_payment_request';
 
     public static function tableName()

--- a/src/views/purse/_client-view.php
+++ b/src/views/purse/_client-view.php
@@ -44,7 +44,7 @@ if ($user->can('document.read') && $user->can('bill.read')) {
                 $user->can('document.read') && $isEmployee ? 'ndas' : null,
                 $user->can('document.read') && $isEmployee ? 'internalinvoices' : null,
                 $user->can('owner-staff') && $user->can('document.read') && !$isEmployee ? 'invoices' : null,
-                $user->can('owner-staff') && $user->can('document.read') && !$isEmployee ? 'proformaInvoices' : null,
+                $user->can('owner-staff') && $user->can('document.read') && !$isEmployee ? 'payment_requestInvoices' : null,
             ], $documents)),
         ]) ?>
     <?php $box->endBody() ?>

--- a/src/views/purse/_client-view.php
+++ b/src/views/purse/_client-view.php
@@ -16,7 +16,7 @@ $documentType = $isEmployee ? 'acceptance' : 'invoice';
 
 $documents = [];
 if ($user->can('document.read') && $user->can('bill.read')) {
-    $documents = ($isEmployee ? ['acceptances'] : ['serviceInvoices', 'purchaseInvoices', 'serviceProformas', 'purchaseProformas']);
+    $documents = ($isEmployee ? ['acceptances'] : ['serviceInvoices', 'purchaseInvoices', 'servicePaymentRequests', 'purchasePaymentRequests']);
 }
 
 ?>

--- a/src/views/requisite/view.php
+++ b/src/views/requisite/view.php
@@ -93,9 +93,9 @@ FlagIconCssAsset::register($this);
                             'model'   => $model,
                             'columns' => [
                                 'reg_data', 'vat_rate',
-                                'invoice_last_no', 'proforma_last_no',
-                                'sinvoice_last_no', 'sproforma_last_no',
-                                'pinvoice_last_no', 'pproforma_last_no',
+                                'invoice_last_no', 'payment_request_last_no',
+                                'sinvoice_last_no', 'spayment_request_last_no',
+                                'pinvoice_last_no', 'ppayment_request_last_no',
                                 'serie', 'registration_number', 'tic',
                             ],
                         ]) ?>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - Renamed all instances of 'proforma' to 'payment_request' across various views and models.
  - Updated corresponding labels and attribute names to reflect these changes.

- **Impact**
  - Enhanced clarity and consistency in naming conventions related to payment requests.
  - Improved user experience by aligning terminology with industry standards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->