### PR TITLE
HP-1983: show `volume_du` resource as `last`

### DIFF
--- a/src/models/proxy/Resource.php
+++ b/src/models/proxy/Resource.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace hipanel\modules\finance\models\proxy;
 
@@ -115,7 +115,7 @@ class Resource extends Model implements DecoratedInterface
 
     private function getLastTypes(): array
     {
-        return ['server_traf95_in', 'server_traf95_max', 'server_traf95', 'ip_num', 'server_files'];
+        return ['server_traf95_in', 'server_traf95_max', 'server_traf95', 'ip_num', 'server_files', 'volume_du'];
     }
 
     public function decorator(): ResourceDecoratorInterface


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added 'volume_du' as a new type in resource tracking, enhancing data granularity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->