### PR TITLE
HP-2079/Unable_to_unlink_parent_plan

### DIFF
--- a/src/actions/LinkParentPlanAction.php
+++ b/src/actions/LinkParentPlanAction.php
@@ -17,8 +17,8 @@ class LinkParentPlanAction extends Action
 
     public function run(int $id, int $client_id, string $type)
     {
-        $parentId = $this->controller->request->post('Plan')['id'] ?? NULL;
-        if (!is_null($parentId)) {
+        if (!empty($this->controller->request->post('Plan'))) {
+            $parentId = $this->controller->request->post('Plan')['id'] ?? NULL;
             try {
                 Plan::perform('link-parent', [
                     'id' => $id,

--- a/src/models/Plan.php
+++ b/src/models/Plan.php
@@ -120,14 +120,11 @@ class Plan extends Model
             [['type', 'state', 'client', 'name', 'plan', 'note', 'currency', 'is_grouping'], 'string'],
 
             [['type', 'name', 'currency'], 'required', 'on' => ['create', 'update']],
-            [['id'], 'required', 'on' => ['update', 'delete', 'set-note']],
-            [['id'], 'required', 'on' => ['delete', 'restore']],
+            [['id'], 'required', 'on' => ['update', 'delete', 'set-note', 'restore', 'link-parent-plan']],
             [['id', 'server_ids'], 'safe', 'on' => ['copy']],
             [['your_tariff', 'is_sold'], 'boolean'],
             [['fee'], 'number'],
             [['custom_attributes', 'data'], 'safe', 'on' => ['create', 'update']],
-            //link-parent-plan
-            [['id'], 'required', 'on' => ['link-parent-plan']],
         ]);
     }
 

--- a/src/models/Plan.php
+++ b/src/models/Plan.php
@@ -126,6 +126,8 @@ class Plan extends Model
             [['your_tariff', 'is_sold'], 'boolean'],
             [['fee'], 'number'],
             [['custom_attributes', 'data'], 'safe', 'on' => ['create', 'update']],
+            //link-parent-plan
+            [['id'], 'required', 'on' => ['link-parent-plan']],
         ]);
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new validation rule requiring the `id` attribute for linking parent plans, enhancing data integrity.
  
- **Bug Fixes**
	- Improved the logic for retrieving `parentId` to ensure it only occurs when valid data is present, streamlining the linking process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->