### PR TITLE
HP-2156: add client tags to charge index

### DIFF
--- a/src/grid/ChargeGridView.php
+++ b/src/grid/ChargeGridView.php
@@ -69,6 +69,7 @@ class ChargeGridView extends BoxedGridView
                 },
             ],
             'client_tags' => [
+                'label' => Yii::t('hipanel:finance', 'Client tags'),
                 'value' => fn(Charge $charge) => $charge->customer?->tags ? implode(', ', $charge->customer->tags) : '',
             ],
             'label' => [

--- a/src/grid/ChargeGridView.php
+++ b/src/grid/ChargeGridView.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * Finance module for HiPanel
  *
@@ -12,7 +12,9 @@ namespace hipanel\modules\finance\grid;
 
 use hipanel\grid\BoxedGridView;
 use hipanel\grid\CurrencyColumn;
+use hipanel\helpers\ArrayHelper;
 use hipanel\helpers\Url;
+use hipanel\modules\client\grid\ClientColumn;
 use hipanel\modules\finance\logic\bill\QuantityFormatterFactoryInterface;
 use hipanel\modules\finance\models\Charge;
 use hipanel\modules\finance\models\ChargeSearch;
@@ -20,8 +22,10 @@ use hipanel\modules\finance\widgets\BillType;
 use hipanel\modules\finance\widgets\BillTypeFilter;
 use hipanel\modules\finance\widgets\LinkToObjectResolver;
 use hipanel\widgets\IconStateLabel;
+use hipanel\widgets\TagsManager;
 use hiqdev\combo\StaticCombo;
 use hiqdev\higrid\DataColumn;
+use ReflectionClass;
 use Yii;
 use yii\helpers\Html;
 
@@ -51,7 +55,22 @@ class ChargeGridView extends BoxedGridView
 
     public function columns()
     {
-        return array_merge(parent::columns(), [
+        return ArrayHelper::merge(parent::columns(), [
+            'client' => [
+                'format' => 'raw',
+                'exportedColumns' => ['client', 'client_tags'],
+                'value' => function (Charge $charge) {
+                    $clientColumn = (new ReflectionClass(ClientColumn::class))->newInstanceWithoutConstructor();
+
+                    return implode("\n", [
+                        $clientColumn->getValue($charge, Yii::$app->user),
+                        TagsManager::widget(['model' => $charge->customer, 'forceReadOnly' => true]),
+                    ]);
+                },
+            ],
+            'client_tags' => [
+                'value' => fn(Charge $charge) => $charge->customer?->tags ? implode(', ', $charge->customer->tags) : '',
+            ],
             'label' => [
                 'attribute' => 'label_ilike',
                 'sortAttribute' => 'label_ilike',
@@ -117,25 +136,25 @@ class ChargeGridView extends BoxedGridView
                 'format' => 'raw',
                 'value' => function (Charge $model) {
                     $result = LinkToObjectResolver::widget([
-                        'model' => $model,
-                        'idAttribute' => 'object_id',
-                        'typeAttribute' => 'class',
-                        'labelAttribute' => 'name',
-                    ]) . ($model->label ? " &ndash; $model->label" : '');
+                            'model' => $model,
+                            'idAttribute' => 'object_id',
+                            'typeAttribute' => 'class',
+                            'labelAttribute' => 'name',
+                        ]) . ($model->label ? " &ndash; $model->label" : '');
 
                     if ($model->commonObject->id !== null && $model->commonObject->id !== $model->latestCommonObject->id) {
                         $result .= ' ' . Html::tag(
-                            'span',
-                            Yii::t('hipanel:finance', 'Now it is in {objectLink}', [
-                                'objectLink' => LinkToObjectResolver::widget([
-                                    'model'          => $model->latestCommonObject,
-                                    'idAttribute'    => 'id',
-                                    'labelAttribute' => 'name',
-                                    'typeAttribute'  => 'type',
+                                'span',
+                                Yii::t('hipanel:finance', 'Now it is in {objectLink}', [
+                                    'objectLink' => LinkToObjectResolver::widget([
+                                        'model' => $model->latestCommonObject,
+                                        'idAttribute' => 'id',
+                                        'labelAttribute' => 'name',
+                                        'typeAttribute' => 'type',
+                                    ]),
                                 ]),
-                            ]),
-                            ['class' => 'badge', 'style' => 'background-color: #f89406;']
-                        );
+                                ['class' => 'badge', 'style' => 'background-color: #f89406;']
+                            );
                     }
 
                     return $result;
@@ -153,7 +172,7 @@ class ChargeGridView extends BoxedGridView
                 'filter' => false,
                 'contentOptions' => ['class' => 'text-nowrap'],
                 'value' => function ($model) {
-                    list($date, $time) = explode(' ', $model->time, 2);
+                    [$date, $time] = explode(' ', $model->time, 2);
 
                     return $model->isMonthly() && $time === '00:00:00'
                         ? Yii::$app->formatter->asDate($date, 'LLLL y')
@@ -166,15 +185,15 @@ class ChargeGridView extends BoxedGridView
                 'enableSorting' => false,
                 'filter' => $this->filterModel !== null
                     ? StaticCombo::widget([
-                          'attribute' => 'is_payed',
-                          'model' => $this->filterModel,
-                          'data' => [
-                              0 => Yii::t('hipanel:finance', 'Charge not paid'),
-                              1 => Yii::t('hipanel:finance', 'Charge paid'),
-                          ],
-                          'hasId' => true,
-                          'inputOptions' => ['id' => 'is_payed'],
-                      ])
+                        'attribute' => 'is_payed',
+                        'model' => $this->filterModel,
+                        'data' => [
+                            0 => Yii::t('hipanel:finance', 'Charge not paid'),
+                            1 => Yii::t('hipanel:finance', 'Charge paid'),
+                        ],
+                        'hasId' => true,
+                        'inputOptions' => ['id' => 'is_payed'],
+                    ])
                     : false,
                 'contentOptions' => ['class' => 'text-center'],
                 'headerOptions' => ['class' => 'text-center'],
@@ -189,19 +208,21 @@ class ChargeGridView extends BoxedGridView
                             Yii::t('hipanel:finance', 'Charge not paid'),
                         ],
                     ]);
-                }
+                },
             ],
             'discount_sum' => [
                 'attribute' => 'discount_sum',
                 'headerOptions' => ['class' => 'text-right'],
-                'value' => fn($charge): string => $charge->discount_sum ? $this->formatter->asCurrency($charge->discount_sum, $charge->currency) : '',
+                'value' => fn($charge): string => $charge->discount_sum ? $this->formatter->asCurrency($charge->discount_sum,
+                    $charge->currency) : '',
                 'enableSorting' => true,
                 'filter' => false,
             ],
             'net_amount' => [
                 'attribute' => 'net_amount',
                 'headerOptions' => ['class' => 'text-right'],
-                'value' => fn($charge): string => $charge->net_amount ? $this->formatter->asCurrency($charge->net_amount, $charge->currency) : '',
+                'value' => fn($charge): string => $charge->net_amount ? $this->formatter->asCurrency($charge->net_amount,
+                    $charge->currency) : '',
                 'enableSorting' => false,
                 'filter' => false,
             ],
@@ -223,7 +244,9 @@ class ChargeGridView extends BoxedGridView
                 'enableSorting' => false,
                 'headerOptions' => ['class' => 'text-right'],
                 'contentOptions' => ['class' => 'text-right'],
-                'value' => fn($charge): string => Html::a($charge->bill_id, ['@bill/view', 'id' => $charge->bill_id], ['target' => '_blank']),
+                'value' => fn($charge): string => Html::a($charge->bill_id,
+                    ['@bill/view', 'id' => $charge->bill_id],
+                    ['target' => '_blank']),
             ],
             'id' => [
                 'attribute' => 'id',

--- a/src/models/Charge.php
+++ b/src/models/Charge.php
@@ -58,7 +58,7 @@ class Charge extends Resource implements HasSumAndCurrencyAttributesInterface, B
             [['id', 'type_id', 'object_id', 'parent_id', 'client_id', 'tariff_id', 'seller_id', 'order_id'], 'integer'],
             [['bill_id', 'id'], 'trim'],
             [['class', 'name', 'unit', 'tariff', 'order_name', 'client', 'seller', 'client_type', 'root_ftype'], 'string'],
-            [['type', 'label', 'ftype', 'time', 'type_label', 'currency', 'exchange_date'], 'safe'],
+            [['type', 'label', 'ftype', 'time', 'type_label', 'currency', 'exchange_date', 'client_tags'], 'safe'],
             [['is_payed'], 'boolean'],
             [['sum', 'quantity', 'bill_quantity', 'positive', 'negative', 'discount_sum', 'net_amount', 'rate', 'eur_amount'], 'number'],
             [['unit'], 'default', 'value' => 'items', 'on' => [self::SCENARIO_CREATE, self::SCENARIO_UPDATE]],
@@ -107,9 +107,14 @@ class Charge extends Resource implements HasSumAndCurrencyAttributesInterface, B
         return $this->hasOne(Bill::class, ['id' => 'id'])->inverseOf('charges');
     }
 
-    public function getCustomer(): ActiveQuery
+    public function getCustomer(): Client
     {
-        return $this->hasOne(Client::class, ['client_id' => 'id']);
+        return new Client([
+            'id' => $this->client_id,
+            'login' => $this->client,
+            'type' => $this->client_type,
+            'tags' => $this->client_tags,
+        ]);
     }
 
     public function isMonthly(): bool

--- a/src/models/Charge.php
+++ b/src/models/Charge.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * Finance module for HiPanel
  *
@@ -10,7 +10,9 @@
 
 namespace hipanel\modules\finance\models;
 
+use hipanel\modules\client\models\Client;
 use hipanel\modules\finance\models\query\ChargeQuery;
+use hiqdev\hiart\ActiveQuery;
 use Yii;
 
 /**
@@ -105,9 +107,14 @@ class Charge extends Resource implements HasSumAndCurrencyAttributesInterface, B
         return $this->hasOne(Bill::class, ['id' => 'id'])->inverseOf('charges');
     }
 
+    public function getCustomer(): ActiveQuery
+    {
+        return $this->hasOne(Client::class, ['client_id' => 'id']);
+    }
+
     public function isMonthly(): bool
     {
-        return strpos($this->ftype, 'monthly,') === 0;
+        return str_starts_with($this->ftype, 'monthly,');
     }
 
     /**

--- a/src/models/query/ChargeQuery.php
+++ b/src/models/query/ChargeQuery.php
@@ -1,5 +1,4 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace hipanel\modules\finance\models\query;
 
@@ -12,6 +11,11 @@ use hiqdev\hiart\ActiveQuery;
  */
 class ChargeQuery extends ActiveQuery
 {
+    public function init()
+    {
+        $this->joinWith('customer');
+    }
+
     public function behaviors(): array
     {
         return [

--- a/src/models/query/ChargeQuery.php
+++ b/src/models/query/ChargeQuery.php
@@ -11,11 +11,6 @@ use hiqdev\hiart\ActiveQuery;
  */
 class ChargeQuery extends ActiveQuery
 {
-    public function init()
-    {
-        $this->joinWith('customer');
-    }
-
     public function behaviors(): array
     {
         return [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added new columns for 'client' and 'client_tags' in the grid view to display client information and associated tags.
	- Introduced a `getCustomer()` method to establish a relationship with the `Client` class.

- **Bug Fixes**
	- Updated the `isMonthly()` method for better string checking logic.

- **Chores**
	- Minor formatting adjustments for improved code readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->