### PR TITLE
HP-2081: fixed overwriting any price class to SinglePrice during creating template prices

### DIFF
--- a/src/views/price/formRow/simple.php
+++ b/src/views/price/formRow/simple.php
@@ -24,6 +24,7 @@ use yii\widgets\ActiveForm;
 
 <?= Html::activeHiddenInput($model, "[$i]object_id", ['ref' => 'object_id']) ?>
 <?= Html::activeHiddenInput($model, "[$i]plan_id") ?>
+<?= Html::activeHiddenInput($model, "[$i]plan_type") ?>
 <?= Html::activeHiddenInput($model, "[$i]type") ?>
 <?= Html::activeHiddenInput($model, "[$i]class") ?>
 <?= Html::activeHiddenInput($model, "[$i]object", ['value' => $model->object->name ?? '']) ?>

--- a/tests/acceptance/seller/TariffPlansCest.php
+++ b/tests/acceptance/seller/TariffPlansCest.php
@@ -13,7 +13,7 @@ use hipanel\modules\finance\tests\_support\Page\price\Create as PriceCreate;
 
 class TariffPlansCest
 {
-    private string $templateName;
+    private string $templateName = '';
 
     public function _before(Seller $I): void
     {


### PR DESCRIPTION
Error was reproducing during launching TariffPlansCest.php:ensureICanCreateNewPlanAndCheckIt Codecept test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a hidden input field for `plan_type` in the price model form, enhancing data capture.
	- Added new properties and methods in the Price class to improve handling of progressive pricing.

- **Improvements**
	- Streamlined progressive pricing management in the PricesCollection class, enhancing modularity and clarity.
	- Enhanced type safety and clarity in the Price class with updated method signatures and new constants.

- **Bug Fixes**
	- Initialized the `$templateName` property in the TariffPlansCest class to ensure defined state before use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->