### PR TITLE
Fix Charge::getBillQuantity() return type

### DIFF
--- a/src/models/Charge.php
+++ b/src/models/Charge.php
@@ -126,7 +126,7 @@ class Charge extends Resource implements HasSumAndCurrencyAttributesInterface, B
         return $this->time;
     }
 
-    public function getBillQuantity(): ?int
+    public function getBillQuantity()
     {
         return $this->bill_quantity;
     }

--- a/src/models/HasBillQuantityAttributeInterface.php
+++ b/src/models/HasBillQuantityAttributeInterface.php
@@ -4,11 +4,11 @@ namespace hipanel\modules\finance\models;
 
 /**
  * @property string|null $quantity
- * @property int|null $bill_quantity
+ * @property int|string|float|null $bill_quantity
  */
 interface HasBillQuantityAttributeInterface
 {
     public function getQuantity();
 
-    public function getBillQuantity(): ?int;
+    public function getBillQuantity();
 }

--- a/tests/unit/logic/bill/QuantityFormatterFactoryTest.php
+++ b/tests/unit/logic/bill/QuantityFormatterFactoryTest.php
@@ -50,23 +50,7 @@ class QuantityFormatterFactoryTest extends TestCase
             }
         };
 
-        $billableTimeContext = new class implements BillableTimeInterface
-        {
-            public function getQuantity()
-            {
-                return 2;
-            }
-
-            public function getBillQuantity(): ?int
-            {
-                return 1;
-            }
-
-            public function getTime(): ?string
-            {
-                return date('Y-m-d H:i:s', strtotime('2024 January'));
-            }
-        };
+        $billableTimeContext = $this->createBillableTimeContext(2, 1);
 
         yield 'other_deposit type with 1 item' => [
             'other_deposit',
@@ -131,5 +115,37 @@ class QuantityFormatterFactoryTest extends TestCase
             $expected = '12 years',
             $expectedClientValue = '12',
         ];
+        yield '0.953 units × 13 days' => [
+            'monthly,rack_unit',
+            Quantity::create('items', "0.41306867283951"),
+            $this->createBillableTimeContext("0.41306867283951", "0.43333333333333"),
+            $expected = '0.953 units &times; 13 days',
+            $expectedClientValue = '0.41306867283951',
+        ];
+    }
+
+    private function createBillableTimeContext($quantity, $billQuantity): BillableTimeInterface
+    {
+        return new class($quantity, $billQuantity) implements BillableTimeInterface
+        {
+            public function __construct(private $quantity, private $billQuantity)
+            {
+            }
+
+            public function getQuantity()
+            {
+                return $this->quantity;
+            }
+
+            public function getBillQuantity()
+            {
+                return $this->billQuantity;
+            }
+
+            public function getTime(): ?string
+            {
+                return date('Y-m-d H:i:s', strtotime('2024 January'));
+            }
+        };
     }
 }

--- a/tests/unit/logic/bill/RackUnitQuantityTest.php
+++ b/tests/unit/logic/bill/RackUnitQuantityTest.php
@@ -24,7 +24,7 @@ class RackUnitQuantityTest extends TestCase
     public function testFormat(
         string $time,
         float $quantity,
-        ?int $billQuantity,
+        $billQuantity,
         string $expectedFormat,
         string $expectedClientValue
     ): void {
@@ -48,6 +48,13 @@ class RackUnitQuantityTest extends TestCase
                 'expectedFormat' => '2 units &times; 31 days',
                 'expectedClientValue' => '2',
             ],
+            'basic scenario float quantity' => [
+                'time' => '2024-01-15',
+                'quantity' => 0.41306867283951,
+                'billQuantity' => 0.43333333333333,
+                'expectedFormat' => '0.953 units &times; 13 days',
+                'expectedClientValue' => '0.41306867283951',
+            ],
             'zero billing quantity' => [
                 'time' => '2024-02-15',
                 'quantity' => 2.0,
@@ -65,7 +72,7 @@ class RackUnitQuantityTest extends TestCase
         ];
     }
 
-    private function createContext(string $time, float $quantity, ?int $billQuantity): BillableTimeInterface
+    private function createContext(string $time, float $quantity, $billQuantity): BillableTimeInterface
     {
         return new class($time, $quantity, $billQuantity) implements BillableTimeInterface
         {
@@ -73,7 +80,7 @@ class RackUnitQuantityTest extends TestCase
             private $quantity;
             private $billQuantity;
 
-            public function __construct(string $time, float $quantity, ?int $billQuantity)
+            public function __construct(string $time, float $quantity, $billQuantity)
             {
                 $this->time = $time;
                 $this->quantity = $quantity;
@@ -85,7 +92,7 @@ class RackUnitQuantityTest extends TestCase
                 return $this->quantity;
             }
 
-            public function getBillQuantity(): ?int
+            public function getBillQuantity()
             {
                 return $this->billQuantity;
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded the range of acceptable types for `bill_quantity`, allowing integers, strings, and floats.
	- Enhanced test coverage with new scenarios for fractional quantities.

- **Bug Fixes**
	- Removed strict return type declarations for `getBillQuantity` methods to increase flexibility in returned values.

- **Tests**
	- Streamlined test setup for `BillableTimeInterface` with a new method for context creation.
	- Added new test cases to cover various quantity formats, including float values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->