### PR TITLE
HP-2192 Fixed note field on create "Create suggested prices" page

### DIFF
--- a/src/views/price/formRow/simple.php
+++ b/src/views/price/formRow/simple.php
@@ -74,7 +74,7 @@ $notePk = $model->id . $model->object_id . $i;
                     'attribute' => 'note',
                     'pluginOptions' => [
                         'selector' => ".editable[data-pk={$notePk}][data-name=note]",
-                        //'data-pk' => $notePk,
+                        'data-pk' => $notePk,
                         'url' => new JsExpression(<<<"JS"
                         function(params) {
                             $(this).closest('.form-instance').parent().find('input[data-attribute=note]').val(params.value);


### PR DESCRIPTION
Fixed note field on create "Create suggested prices" page by uncommenting data-pk parameter in pluginOptions of XEditable widget (which was commented by mistake during testing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `XEditable` widget functionality by ensuring the primary key is correctly referenced for editable notes.
  
- **Bug Fixes**
	- Activated the previously commented-out `data-pk` attribute for proper operation of the editable field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->