### PR TITLE
HP-2216: show `-`  for the month has no any estimated price, before…

### DIFF
--- a/src/controllers/PlanController.php
+++ b/src/controllers/PlanController.php
@@ -448,7 +448,7 @@ class PlanController extends CrudController
 
     private function calculateDataForPeriods(string $action, array $data = []): array
     {
-        Yii::$app->response->format = Response::FORMAT_JSON;
+        $this->response->format = Response::FORMAT_JSON;
         $times = ['now', 'first day of +1 month', 'first day of +1 year'];
 
         try {

--- a/src/grid/ValueColumn.php
+++ b/src/grid/ValueColumn.php
@@ -41,7 +41,10 @@ class ValueColumn extends Column
         return Html::tag('span', Html::tag('span', Html::tag('i', $fields, [
             'class' => 'fa fa-refresh fa-spin fa-fw',
             'data' => ['id' => $model->id],
-        ]), ['class' => 'price-estimates']), ['class' => 'price-item', 'data' => ['id' => $model->id]]);
+        ]), ['class' => 'price-estimates']), ['class' => 'price-item', 'data' => [
+            'id' => $model->id,
+            'currency' => mb_strtoupper($model->currency),
+        ]]);
     }
 
     private function registerClientScript()
@@ -53,7 +56,7 @@ class ValueColumn extends Column
             "
         ;(function ($, window, document, undefined) {
             let Estimator = $('#bulk-plan').priceEstimator({
-                url: '${calculateValueUrl}',
+                url: '$calculateValueUrl',
                 estimatePlan: true,
                 rowSelector: '.price-item',
                 totalCellSelector: '#plan-monthly-value',

--- a/src/helpers/PriceChargesEstimator.php
+++ b/src/helpers/PriceChargesEstimator.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * Finance module for HiPanel
  *
@@ -16,6 +16,7 @@ use Money\Currency;
 use Money\Formatter\DecimalMoneyFormatter;
 use Money\Money;
 use Yii;
+use yii\i18n\Formatter;
 
 /**
  * Class PriceChargesEstimator.
@@ -24,23 +25,14 @@ use Yii;
  */
 class PriceChargesEstimator
 {
-    /**
-     * @var \yii\i18n\Formatter
-     */
-    protected $yiiFormatter;
-    /**
-     * @var DecimalMoneyFormatter
-     */
-    protected $moneyFormatter;
-    /**
-     * @var array
-     */
-    protected $calculations = [];
+    protected Formatter $yiiFormatter;
+    protected DecimalMoneyFormatter $moneyFormatter;
+    protected array $calculations = [];
 
     /**
      * @var string[] array of strings compatible with `strtotime()`, e.g. `first day of next month`
      */
-    private $periods = [];
+    protected array $periods = [];
 
     public function __construct(array $calculations)
     {
@@ -49,23 +41,23 @@ class PriceChargesEstimator
         $this->moneyFormatter = new DecimalMoneyFormatter(new ISOCurrencies());
     }
 
-    public function __invoke($periods)
+    public function __invoke($periods): void
     {
         $this->calculateForPeriods($periods);
     }
 
     /**
-     * @var string[] array of strings compatible with `strtotime()`, e.g. `first day of next month`
      * @return array
+     * @var string[] $periods array of strings compatible with `strtotime()`, e.g. `first day of next month`
      */
-    public function calculateForPeriods($periods): array
+    public function calculateForPeriods(array $periods): array
     {
         $this->periods = $periods;
 
         return $this->groupCalculationsByTarget();
     }
 
-    private function groupCalculationsByTarget()
+    private function groupCalculationsByTarget(): array
     {
         $result = [];
 
@@ -96,7 +88,10 @@ class PriceChargesEstimator
                     $charge['action']['quantity']['quantity'],
                     $chargesByTargetAndAction['targets'][$targetId][$actionType]['quantity'] ?? 0
                 );
-                $chargesByTargetAndAction['sumFormatted'] = $this->yiiFormatter->asCurrency($chargesByTargetAndAction['sum'], $sum['currency']);
+                $chargesByTargetAndAction['sumFormatted'] = $this->yiiFormatter->asCurrency(
+                    $chargesByTargetAndAction['sum'],
+                    $sum['currency']
+                );
             }
             unset($action);
 
@@ -115,7 +110,7 @@ class PriceChargesEstimator
         return $result;
     }
 
-    private function decorateAction(&$action)
+    private function decorateAction(&$action): void
     {
         $action['sum'] = array_sum(array_column($action['charges'], 'price'));
         $action['currency'] = reset($action['charges'])['currency'];


### PR DESCRIPTION
… this it removed one of the three values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced the `PriceEstimator` plugin to better manage and display pricing information with improved context handling.
	- Introduced additional data attributes for currency in the rendered output of the `ValueColumn` class.

- **Bug Fixes**
	- Corrected JavaScript variable interpolation for URL handling in the `ValueColumn` class.

- **Chores**
	- Improved type safety and clarity in the `PriceChargesEstimator` and `LightPriceChargesEstimator` classes by updating method signatures and property types.

These changes collectively enhance the user experience by providing more accurate pricing estimates and improved functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->