### PR TITLE
HP-2148: exclude first day of next period

### DIFF
--- a/src/models/ConsumptionSearch.php
+++ b/src/models/ConsumptionSearch.php
@@ -24,7 +24,7 @@ class ConsumptionSearch extends Consumption
             [['time_from', 'time_till'], 'date', 'format' => 'php:Y-m-d'],
             [['groupby'], 'string'],
             ['time_from', 'default', 'value' => $date->modify('first day of this month')->format('Y-m-d')],
-            ['time_till', 'default', 'value' => $date->modify('first day of next month')->format('Y-m-d')],
+            ['time_till', 'default', 'value' => $date->modify('last day of this month')->format('Y-m-d')],
             ['groupby', 'default', 'value' => 'month'],
         ]);
     }

--- a/src/widgets/MonthRangePicker.php
+++ b/src/widgets/MonthRangePicker.php
@@ -40,7 +40,7 @@ final class MonthRangePicker extends Widget
               const date = evt.viewDate;
               const form = $(evt.target).closest('form');
               form.find('input[name*=$this->timeFromAttribute]').val(date.startOf('month').format('YYYY-MM-DD'));
-              form.find('input[name*=$this->timeTillAttribute]').val(date.add(1, 'month').startOf('month').format('YYYY-MM-DD'));
+              form.find('input[name*=$this->timeTillAttribute]').val(date.endOf('month').format('YYYY-MM-DD'));
             });
 JS
         );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated default date range for searches to end on the last day of the current month.
	- Enhanced date selection logic in the Month Range Picker for more accurate end date selection.

- **Bug Fixes**
	- Corrected the calculation of the end date in the Month Range Picker to reflect the actual end of the selected month.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->