### PR TITLE
HP-2309 fixed displaying price formatting on finance/plan/view page and tiny refactor

### DIFF
--- a/src/grid/presenters/price/ProgressivePricePresenter.php
+++ b/src/grid/presenters/price/ProgressivePricePresenter.php
@@ -16,23 +16,32 @@ class ProgressivePricePresenter extends PricePresenter
             return parent::renderPrice($price);
         }
         $result = [];
-        $toLine = fn($price, $currency, $unit, $quantity): string => Yii::t('hipanel:finance',
-            "{sum} per {unit} over {quantity} {unit}",
-            [
-                'sum' => Html::tag('b', $this->formatter->asCurrency($price, $currency, [
-                    NumberFormatter::MIN_FRACTION_DIGITS => 2,
-                    NumberFormatter::MAX_FRACTION_DIGITS => 6,
-                ])),
-                'currency' => $currency,
-                'quantity' => $quantity,
-                'unit' => $unit,
-            ]
-        );
-        $result[] = $toLine($price->price, $price->currency, $price->getUnitLabel(), $price->quantity);
+        $result[] = $this->toLine($price->price, $price->currency, $price->getUnitLabel(), $price->quantity);
         foreach ($thresholds as $threshold) {
-            $result[] = $toLine($threshold->price, $threshold->currency, $threshold->getUnitLabel(), $threshold->quantity);
+            $result[] = $this->toLine($threshold->price, $threshold->currency, $threshold->getUnitLabel(), $threshold->quantity);
         }
 
         return nl2br(implode("\n", $result));
+    }
+
+    private function toLine(?string $price, string $currency, ?string $unit, string $quantity): string
+    {
+        return Yii::t('hipanel:finance',
+            "{sum} per {unit} over {quantity} {unit}",
+            [
+                'sum' => Html::tag('b', $this->formatSumAsCurrency($price, $currency)),
+                'unit' => $unit,
+                'currency' => $currency,
+                'quantity' => $quantity,
+            ]
+        );
+    }
+
+    private function formatSumAsCurrency(?string $price, string $currency): string
+    {
+        return $this->formatter->asCurrency($price, $currency, [
+            NumberFormatter::MIN_FRACTION_DIGITS => 2,
+            NumberFormatter::MAX_FRACTION_DIGITS => 6,
+        ]);
     }
 }

--- a/tests/playwright/e2e/manager/progressive-price.spec.ts
+++ b/tests/playwright/e2e/manager/progressive-price.spec.ts
@@ -46,7 +46,7 @@ test("Test the Progressive Price feature works @hipanel-module-finance @manager"
 
   await page.getByRole("button", { name: "Save" }).click();
 
-  await expect(page.getByRole("cell", { name: "$30.00 per Pcs over 0 Pcs $0.0085 per Pcs over 1 Pcs $0.008 per Pcs over 2 Pcs $0.0075 per Pcs over 3 Pcs" })).toBeVisible();
+  await expect(page.getByRole("cell", { name: "$30.00 per items over 0 items $0.0085 per items over 1 items $0.008 per items over 2 items $0.0075 per items over 3 items" })).toBeVisible();
 
   await expect(page.getByText("Number of IPs")).toBeVisible();
   await page.locator("input[name=\"selection_all\"]").check();
@@ -54,7 +54,7 @@ test("Test the Progressive Price feature works @hipanel-module-finance @manager"
   await page.getByRole("button", { name: "" }).nth(2).click();
   await page.locator("#threshold-0-2-price").fill("0.0075");
   await page.getByRole("button", { name: "Save" }).click();
-  await expect(page.getByRole("grid")).toContainText("$30.00 per Pcs over 0 Pcs $0.0085 per Pcs over 1 Pcs $0.0075 per Pcs over 2 Pcs");
+  await expect(page.getByRole("grid")).toContainText("$30.00 per items over 0 Pcs $0.0085 per items over 1 items $0.0075 per items over 2 items");
 
   page.on("dialog", async dialog => {
     await dialog.accept();

--- a/tests/playwright/e2e/manager/progressive-price.spec.ts
+++ b/tests/playwright/e2e/manager/progressive-price.spec.ts
@@ -54,7 +54,7 @@ test("Test the Progressive Price feature works @hipanel-module-finance @manager"
   await page.getByRole("button", { name: "" }).nth(2).click();
   await page.locator("#threshold-0-2-price").fill("0.0075");
   await page.getByRole("button", { name: "Save" }).click();
-  await expect(page.getByRole("grid")).toContainText("$30.00 per Item over 0 Pcs $0.0085 per Item over 1 Item $0.0075 per Item over 2 Item");
+  await expect(page.getByRole("grid")).toContainText("$30.00 per Item over 0 Item $0.0085 per Item over 1 Item $0.0075 per Item over 2 Item");
 
   page.on("dialog", async dialog => {
     await dialog.accept();

--- a/tests/playwright/e2e/manager/progressive-price.spec.ts
+++ b/tests/playwright/e2e/manager/progressive-price.spec.ts
@@ -46,7 +46,7 @@ test("Test the Progressive Price feature works @hipanel-module-finance @manager"
 
   await page.getByRole("button", { name: "Save" }).click();
 
-  await expect(page.getByRole("cell", { name: "$30.00 per items over 0 items $0.0085 per items over 1 items $0.008 per items over 2 items $0.0075 per items over 3 items" })).toBeVisible();
+  await expect(page.getByRole("cell", { name: "$30.00 per Item over 0 Item $0.0085 per Item over 1 Item $0.008 per Item over 2 Item $0.0075 per Item over 3 Item" })).toBeVisible();
 
   await expect(page.getByText("Number of IPs")).toBeVisible();
   await page.locator("input[name=\"selection_all\"]").check();
@@ -54,7 +54,7 @@ test("Test the Progressive Price feature works @hipanel-module-finance @manager"
   await page.getByRole("button", { name: "" }).nth(2).click();
   await page.locator("#threshold-0-2-price").fill("0.0075");
   await page.getByRole("button", { name: "Save" }).click();
-  await expect(page.getByRole("grid")).toContainText("$30.00 per items over 0 Pcs $0.0085 per items over 1 items $0.0075 per items over 2 items");
+  await expect(page.getByRole("grid")).toContainText("$30.00 per Item over 0 Pcs $0.0085 per Item over 1 Item $0.0075 per Item over 2 Item");
 
   page.on("dialog", async dialog => {
     await dialog.accept();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- No new features added

- **Bug Fixes**
	- Updated pricing terminology from "Pcs" to "Item" in progressive price displays

- **Documentation**
	- Improved code structure for price rendering and currency formatting

- **Style**
	- Consistent terminology update in pricing display and test assertions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->