### PR TITLE
HP-2347: tune target CRUD

### DIFF
--- a/config/web.php
+++ b/config/web.php
@@ -187,6 +187,13 @@ return [
                         'model' => Target::class,
                         'resourceModel' => TargetResource::class,
                     ],
+                    'switch_license' => [
+                        'label' => ['hipanel:finance', 'Switch License'],
+                        'columns' => [],
+                        'groups' => [],
+                        'model' => Target::class,
+                        'resourceModel' => TargetResource::class,
+                    ],
                     'volume' => [
                         'label' => ['hipanel:finance', 'Volume'],
                         'columns' => ['volume_du'],

--- a/src/controllers/PlanController.php
+++ b/src/controllers/PlanController.php
@@ -233,8 +233,13 @@ class PlanController extends CrudController
             'plan_id' => $plan->id,
             'plan_type' => $plan->type,
         ]);
+        $queryParams = $this->request->get();
 
-        return $this->renderAjax('modals/suggestPrices', compact('plan', 'model'));
+        return $this->renderAjax('modals/suggestPrices', [
+            'plan' => $plan,
+            'model' => $model,
+            'withSwitchLicense' => isset($queryParams['switch_license']),
+        ]);
     }
 
     public function actionSuggestCalculatorPricesModal($id, $type)

--- a/src/controllers/TargetController.php
+++ b/src/controllers/TargetController.php
@@ -4,29 +4,29 @@ declare(strict_types=1);
 
 namespace hipanel\modules\finance\controllers;
 
-use Yii;
-use yii\base\Event;
-use hipanel\base\Module;
-use hiqdev\hiart\Collection;
-use hipanel\actions\ViewAction;
-use hipanel\actions\IndexAction;
-use hipanel\base\CrudController;
-use hipanel\actions\SearchAction;
 use hipanel\actions\ComboSearchAction;
+use hipanel\actions\IndexAction;
+use hipanel\actions\SearchAction;
 use hipanel\actions\SmartCreateAction;
 use hipanel\actions\SmartDeleteAction;
-use hipanel\actions\SmartUpdateAction;
-use hipanel\filters\EasyAccessControl;
 use hipanel\actions\SmartPerformAction;
+use hipanel\actions\SmartUpdateAction;
 use hipanel\actions\ValidateFormAction;
-use hipanel\modules\finance\models\Plan;
-use hipanel\modules\finance\models\Target;
-use hipanel\modules\finance\models\query\TargetQuery;
-use hipanel\modules\finance\forms\TargetManagementForm;
-use hipanel\modules\finance\actions\TargetManagementAction;
-use hipanel\modules\finance\providers\ConsumptionsProvider;
-use hipanel\modules\finance\helpers\ConsumptionConfigurator;
+use hipanel\actions\ViewAction;
+use hipanel\base\CrudController;
+use hipanel\base\Module;
+use hipanel\filters\EasyAccessControl;
 use hipanel\modules\client\models\stub\ClientRelationFreeStub;
+use hipanel\modules\finance\actions\TargetManagementAction;
+use hipanel\modules\finance\forms\TargetManagementForm;
+use hipanel\modules\finance\helpers\ConsumptionConfigurator;
+use hipanel\modules\finance\models\Plan;
+use hipanel\modules\finance\models\query\TargetQuery;
+use hipanel\modules\finance\models\Target;
+use hipanel\modules\finance\providers\ConsumptionsProvider;
+use hiqdev\hiart\Collection;
+use Yii;
+use yii\base\Event;
 
 class TargetController extends CrudController
 {
@@ -36,7 +36,8 @@ class TargetController extends CrudController
         readonly private ConsumptionConfigurator $consumptionConfigurator,
         readonly private ConsumptionsProvider $consumptionsProvider,
         array $config = []
-    ) {
+    )
+    {
         parent::__construct($id, $module, $config);
     }
 
@@ -48,9 +49,9 @@ class TargetController extends CrudController
                 'actions' => [
                     'restore' => ['test.alpha'],
                     '*' => ['plan.read', 'price.read'],
-                    // 'create' => 'target.create',
-                    // 'update' => 'target.update',
-                    // 'delete' => 'target.delete',
+                    'create' => 'target.create',
+                    'update' => 'target.update',
+                    'delete' => 'target.delete',
                 ],
             ],
         ]);

--- a/src/controllers/TargetController.php
+++ b/src/controllers/TargetController.php
@@ -4,25 +4,29 @@ declare(strict_types=1);
 
 namespace hipanel\modules\finance\controllers;
 
-use hipanel\actions\ComboSearchAction;
-use hipanel\actions\IndexAction;
-use hipanel\actions\SearchAction;
-use hipanel\actions\SmartPerformAction;
-use hipanel\actions\ValidateFormAction;
-use hipanel\actions\ViewAction;
-use hipanel\base\CrudController;
-use hipanel\filters\EasyAccessControl;
-use hipanel\modules\client\models\stub\ClientRelationFreeStub;
-use hipanel\modules\finance\actions\TargetManagementAction;
-use hipanel\modules\finance\forms\TargetManagementForm;
-use hipanel\modules\finance\models\Plan;
-use hipanel\modules\finance\models\query\TargetQuery;
-use hipanel\modules\finance\models\Target;
-use hipanel\modules\finance\helpers\ConsumptionConfigurator;
-use hipanel\modules\finance\providers\ConsumptionsProvider;
+use Yii;
+use yii\base\Event;
 use hipanel\base\Module;
 use hiqdev\hiart\Collection;
-use yii\base\Event;
+use hipanel\actions\ViewAction;
+use hipanel\actions\IndexAction;
+use hipanel\base\CrudController;
+use hipanel\actions\SearchAction;
+use hipanel\actions\ComboSearchAction;
+use hipanel\actions\SmartCreateAction;
+use hipanel\actions\SmartDeleteAction;
+use hipanel\actions\SmartUpdateAction;
+use hipanel\filters\EasyAccessControl;
+use hipanel\actions\SmartPerformAction;
+use hipanel\actions\ValidateFormAction;
+use hipanel\modules\finance\models\Plan;
+use hipanel\modules\finance\models\Target;
+use hipanel\modules\finance\models\query\TargetQuery;
+use hipanel\modules\finance\forms\TargetManagementForm;
+use hipanel\modules\finance\actions\TargetManagementAction;
+use hipanel\modules\finance\providers\ConsumptionsProvider;
+use hipanel\modules\finance\helpers\ConsumptionConfigurator;
+use hipanel\modules\client\models\stub\ClientRelationFreeStub;
 
 class TargetController extends CrudController
 {
@@ -32,8 +36,7 @@ class TargetController extends CrudController
         readonly private ConsumptionConfigurator $consumptionConfigurator,
         readonly private ConsumptionsProvider $consumptionsProvider,
         array $config = []
-    )
-    {
+    ) {
         parent::__construct($id, $module, $config);
     }
 
@@ -45,6 +48,9 @@ class TargetController extends CrudController
                 'actions' => [
                     'restore' => ['test.alpha'],
                     '*' => ['plan.read', 'price.read'],
+                    // 'create' => 'target.create',
+                    // 'update' => 'target.update',
+                    // 'delete' => 'target.delete',
                 ],
             ],
         ]);
@@ -58,6 +64,21 @@ class TargetController extends CrudController
             ],
             'index' => [
                 'class' => IndexAction::class,
+            ],
+            'create' => [
+                'class' => SmartCreateAction::class,
+                'success' => Yii::t('hipanel:finance', 'Target was successfully created'),
+            ],
+            'update' => [
+                'class' => SmartUpdateAction::class,
+                'success' => Yii::t('hipanel:finance', 'Target was successfully updated'),
+                'on beforeFetch' => function (Event $event) {
+                    $event->sender->getDataProvider()->query->andWhere(['show_deleted' => 1]);
+                },
+            ],
+            'delete' => [
+                'class' => SmartDeleteAction::class,
+                'success' => Yii::t('hipanel:finance:sale', 'Target was successfully deleted.'),
             ],
             'change-plan' => [
                 'class' => TargetManagementAction::class,

--- a/src/grid/TargetGridView.php
+++ b/src/grid/TargetGridView.php
@@ -17,11 +17,19 @@ class TargetGridView extends ContactGridView
             'name' => [
                 'class' => MainColumn::class,
                 'exportedColumns' => ['tags', 'name'],
+                'filterAttribute' => 'name_like',
+            ],
+            'state' => [
+                'filter' => $this->filterModel?->states,
+                'filterInputOptions' => ['prompt' => '--', 'class' => 'form-control'],
             ],
             'type' => [
                 'filter' => $this->filterModel?->types,
-                'filterInputOptions' => ['class' => 'form-control'],
+                'filterInputOptions' => ['prompt' => '--', 'class' => 'form-control'],
                 'value' => static fn(Target $target): string => Yii::t('hipanel:finance', $target->type),
+            ],
+            'remoteid' => [
+                'filterAttribute' => 'remoteid_like',
             ],
             'actions' => [
                 'class' => MenuColumn::class,

--- a/src/grid/TargetRepresentations.php
+++ b/src/grid/TargetRepresentations.php
@@ -22,11 +22,13 @@ class TargetRepresentations extends RepresentationCollection
                 'label' => Yii::t('hipanel', 'Common'),
                 'columns' => array_filter([
                     'checkbox',
+                    'actions',
                     'name',
                     'client',
                     'seller',
                     'type',
                     'state',
+                    'remoteid',
                     'tariff',
                 ]),
             ],

--- a/src/menus/TargetActionsMenu.php
+++ b/src/menus/TargetActionsMenu.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace hipanel\modules\finance\menus;
 
-use hipanel\modules\finance\models\Target;
+use Yii;
 use hiqdev\yii2\menus\Menu;
+use hipanel\modules\finance\models\Target;
 
 class TargetActionsMenu extends Menu
 {
@@ -11,6 +14,29 @@ class TargetActionsMenu extends Menu
 
     public function items()
     {
-        return [];
+        $user = Yii::$app->user;
+
+        return [
+            'update' => [
+                'label' => Yii::t('hipanel', 'Update'),
+                'icon' => 'fa-pencil-square-o',
+                'url' => ['@target/update', 'id' => $this->model->id],
+                'visible' => $user->can('plan.update'),
+            ],
+            'delete' => [
+                'label' => Yii::t('hipanel', 'Delete'),
+                'icon' => 'fa-trash',
+                'url' => ['@target/delete', 'id' => $this->model->id],
+                'encode' => false,
+                'visible' => $user->can('plan.delete'),
+                'linkOptions' => [
+                    'data' => [
+                        'confirm' => Yii::t('hipanel', 'Are you sure you want to delete this target?'),
+                        'method' => 'POST',
+                        'pjax' => '0',
+                    ],
+                ],
+            ],
+        ];
     }
 }

--- a/src/menus/TargetDetailMenu.php
+++ b/src/menus/TargetDetailMenu.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace hipanel\modules\finance\menus;
 
 use hipanel\helpers\Url;
@@ -21,8 +23,9 @@ class TargetDetailMenu extends AbstractDetailMenu
         ])->items();
         $hasSales = count($this->model->sales) > 0;
         $hasActiveSale = $this->model->getActiveSale() !== null;
+        $user = Yii::$app->user;
 
-        $items = array_merge($items, [
+        $items = array_merge([
             [
                 'label' => AjaxModalWithTemplatedButton::widget([
                     'ajaxModalOptions' => [
@@ -36,7 +39,7 @@ class TargetDetailMenu extends AbstractDetailMenu
                         'header' => Html::tag('h4', Yii::t('hipanel:finance', 'Change plan'), ['class' => 'modal-title']),
                         'toggleButton' => [
                             'tag' => 'a',
-                            'label' => Yii::t('hipanel:finance', 'Change plan') . '<span class="pull-right"><i class="fa fa-fw fa-pencil"></i></span>',
+                            'label' => Yii::t('hipanel:finance', 'Change plan') . '<span class="pull-right"><i class="fa fa-fw fa-files-o"></i></span>',
                             'class' => 'clickable',
                         ],
                     ],
@@ -89,7 +92,7 @@ class TargetDetailMenu extends AbstractDetailMenu
                 'visible' => $hasActiveSale && !$this->model->isDeleted(),
                 'encode' => false,
             ],
-        ]);
+        ], $items);
 
         unset($items['view']);
 

--- a/src/models/Target.php
+++ b/src/models/Target.php
@@ -1,14 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace hipanel\modules\finance\models;
 
 use hipanel\base\Model;
 use hipanel\base\ModelTrait;
 use hipanel\behaviors\TaggableBehavior;
+use hipanel\models\Ref;
 use hipanel\models\TaggableInterface;
 use hipanel\modules\finance\helpers\ConsumptionConfigurator;
 use hipanel\modules\finance\models\query\TargetQuery;
 use Yii;
+use yii\db\Query;
 
 /**
  * @property Sale[] $sales
@@ -32,9 +36,31 @@ class Target extends Model implements TaggableInterface
     {
         return [
             [['id', 'type_id', 'state_id', 'client_id', 'access_id', 'tariff_id', 'seller_id'], 'integer'],
-            [['type', 'state', 'client', 'name', 'tariff', 'seller'], 'string'],
+            [['type', 'state', 'client', 'name', 'tariff', 'seller', 'remoteid'], 'string'],
             [['show_deleted'], 'boolean'],
             [['id'], 'required', 'on' => ['restore']],
+            [['name', 'type', 'state', 'client'], 'required', 'on' => ['create', 'update']],
+            [
+                ['name'],
+                'unique',
+                'targetAttribute' => ['name', 'type'],
+                'filter' => function (Query $query): void {
+                    $query->andWhere(['ne', 'id', $this->id]);
+                },
+                'message' => Yii::t('hipanel:finance', 'The combination Name and Type has already been taken.'),
+                'on' => ['create', 'update'],
+            ],
+            [
+                ['remoteid'],
+                'unique',
+                'targetAttribute' => ['remoteid', 'type', 'access_id'],
+                'filter' => function (Query $query): void {
+                    $query->andWhere(['ne', 'id', $this->id]);
+                },
+                'message' => Yii::t('hipanel:finance', 'The combination Remote ID, Access ID and Type has already been taken.'),
+                'on' => ['create', 'update'],
+            ],
+            [['id'], 'required', 'on' => 'delete'],
         ];
     }
 
@@ -53,11 +79,18 @@ class Target extends Model implements TaggableInterface
         return $types;
     }
 
+    public function getStates(): array
+    {
+        return Ref::getList('state,target', 'hipanel:finance');
+    }
+
     public function attributeLabels(): array
     {
         return array_merge(parent::attributeLabels(), [
             'show_deleted' => Yii::t('hipanel:finance', 'Show deleted'),
             'tariff_id' => Yii::t('hipanel:finance', 'Tariff'),
+            'state_id' => Yii::t('hipanel:finance', 'State'),
+            'type_id' => Yii::t('hipanel:finance', 'Type'),
         ]);
     }
 

--- a/src/views/target/_form.php
+++ b/src/views/target/_form.php
@@ -1,0 +1,52 @@
+<?php
+
+use hipanel\modules\client\widgets\combo\ClientCombo;
+use yii\helpers\Html;
+use yii\widgets\ActiveForm;
+
+?>
+
+<?php $form = ActiveForm::begin([
+    'id' => 'target-form',
+    'enableClientValidation' => true,
+    'validateOnBlur' => true,
+]) ?>
+
+<div class="row">
+    <div class="col-lg-4 col-md-6">
+        <div class="box box-widget sales">
+            <div class="box-body">
+                <div class="row">
+                    <?php if (!$model->isNewRecord) : ?>
+                        <?= $form->field($model, 'id')->hiddenInput()->label(false) ?>
+                    <?php endif ?>
+                    <div class="col-md-12">
+                        <?= $form->field($model, 'name')->textInput() ?>
+                    </div>
+                    <div class="col-md-12">
+                        <div class="row">
+                            <div class="col-md-6">
+                                <?= $form->field($model, 'client')->widget(ClientCombo::class) ?>
+                            </div>
+                            <div class="col-md-6">
+                                <?= $form->field($model, 'remoteid')->textInput() ?>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <?= $form->field($model, 'type')->dropDownList($model->types, ['prompt' => '--']) ?>
+                    </div>
+                    <div class="col-md-6">
+                        <?= $form->field($model, 'state')->dropDownList($model->states) ?>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?= Html::submitButton(Yii::t('hipanel', 'Save'), ['class' => 'btn btn-success']) ?>
+&nbsp;
+<?= Html::button(Yii::t('hipanel', 'Cancel'), ['class' => 'btn btn-default', 'onclick' => 'history.go(-1)']) ?>
+
+<?php ActiveForm::end() ?>

--- a/src/views/target/create.php
+++ b/src/views/target/create.php
@@ -1,0 +1,14 @@
+<?php
+
+use hipanel\modules\finance\models\Target;
+
+/** @var Target $model */
+/** @var Target[] $models */
+
+$this->title = Yii::t('hipanel:finance', 'Create');
+$this->params['breadcrumbs'][] = ['label' => Yii::t('hipanel:finance', 'Targets'), 'url' => ['index']];
+$this->params['breadcrumbs'][] = $this->title;
+
+?>
+
+<?= $this->render('_form', ['models' => $models, 'model' => $model]) ?>

--- a/src/views/target/index.php
+++ b/src/views/target/index.php
@@ -1,11 +1,12 @@
 <?php
 
-use hipanel\models\IndexPageUiOptions;
-use hipanel\modules\finance\grid\TargetGridView;
-use hipanel\modules\finance\models\Target;
+use yii\helpers\Html;
 use hipanel\widgets\IndexPage;
-use hiqdev\higrid\representations\RepresentationCollection;
 use yii\data\DataProviderInterface;
+use hipanel\models\IndexPageUiOptions;
+use hipanel\modules\finance\models\Target;
+use hipanel\modules\finance\grid\TargetGridView;
+use hiqdev\higrid\representations\RepresentationCollection;
 
 /** @var Target $model */
 /** @var DataProviderInterface $dataProvider */
@@ -22,6 +23,12 @@ $this->params['breadcrumbs'][] = $this->title;
 <?php $page = IndexPage::begin(compact('model', 'dataProvider')) ?>
 
     <?php $page->setSearchFormData() ?>
+
+    <?php $page->beginContent('main-actions') ?>
+        <?php if (Yii::$app->user->can('plan.create')) : ?>
+            <?= Html::a(Yii::t('hipanel:finance', 'Create'), ['@target/create'], ['class' => 'btn btn-sm btn-success']) ?>
+        <?php endif ?>
+    <?php $page->endContent() ?>
 
     <?php $page->beginContent('sorter-actions') ?>
         <?= $page->renderSorter([

--- a/src/views/target/update.php
+++ b/src/views/target/update.php
@@ -1,0 +1,18 @@
+<?php
+
+use yii\helpers\Html;
+use hipanel\modules\finance\models\Target;
+
+/** @var Target $model */
+/** @var Target[] $models */
+
+$this->title = Yii::t('hipanel:finance', 'Update');
+$this->params['breadcrumbs'][] = ['label' => Yii::t('hipanel:finance', 'Targets'), 'url' => ['index']];
+if (count($models) === 1) {
+    $this->params['breadcrumbs'][] = ['label' => Html::encode($model->name), 'url' => ['view', 'id' => $model->id]];
+}
+$this->params['breadcrumbs'][] = $this->title;
+
+?>
+
+<?= $this->render('_form', ['models' => $models, 'model' => $model]) ?>

--- a/src/views/target/update.php
+++ b/src/views/target/update.php
@@ -1,7 +1,7 @@
 <?php
 
-use yii\helpers\Html;
 use hipanel\modules\finance\models\Target;
+use yii\helpers\Html;
 
 /** @var Target $model */
 /** @var Target[] $models */

--- a/src/widgets/CreatePricesButton.php
+++ b/src/widgets/CreatePricesButton.php
@@ -66,7 +66,7 @@ class CreatePricesButton extends Widget
         return Html::tag('div', Html::a(Yii::t('hipanel.finance.price', 'Create prices') .
                 '&nbsp;&nbsp;' .
                 Html::tag('span', null, ['class' => 'caret']), '#', [
-                'data-toggle' => 'dropdown', 'class' => 'dropdown-toggle btn btn-success btn-sm',
+                'data-toggle' => 'dropdown', 'class' => 'dropdown-toggle btn btn-success btn-sm', 'style' => ['margin-right' => '0.3rem'],
             ]) . Dropdown::widget([
                 'options' => ['class' => 'pull-right'],
                 'items' => array_filter([

--- a/src/widgets/combo/target/SwitchLicenceCombo.php
+++ b/src/widgets/combo/target/SwitchLicenceCombo.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace hipanel\modules\finance\widgets\combo\target;
+
+use hipanel\modules\finance\widgets\combo\TargetCombo;
+
+class SwitchLicenceCombo extends TargetCombo
+{
+    public array $targetType = ['switch_license'];
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a license switching option with a new tabbed interface in the pricing modal.
	- Enabled complete create, update, and delete operations for finance items with success feedback.
	- Launched new, enhanced forms for managing finance entries.
	- Added a new `SwitchLicenceCombo` widget for selecting license targets.
	- Implemented a user interface element to allow users with permissions to create new targets.
- **Refactor**
	- Upgraded filtering options and data grid displays for improved list management.
	- Streamlined action menus to dynamically show options based on user permissions.
- **Style**
	- Applied minor UI adjustments to enhance spacing and overall button layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->