### PR TITLE
HP-2457 Disable unsupported 'twoco' merchant to suppress recurring Sentry/Slack warnings

### DIFF
--- a/src/merchant/PurchaseRequestCollection.php
+++ b/src/merchant/PurchaseRequestCollection.php
@@ -35,7 +35,6 @@ class PurchaseRequestCollection extends Collection
         'freekassa' => 1,
         'bitpay' => 1,
         'epayservice' => 1,
-        'twoco' => 1,
         'epayments' => 1,
         'ikajo' => 1,
         'coingate' => 1,


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/bea6410f-934d-454c-a2ee-55c497138bab)
![image](https://github.com/user-attachments/assets/827b1ef2-6163-4ac5-bba1-a0d1a89f8b19)

https://sentry.hiqdev.com/organizations/hiqdev/issues/46997