### PR TITLE
HP-2301 fix 'Attempt to read property "ts" on null' warning on finance/bill/index page

### DIFF
--- a/src/controllers/BillController.php
+++ b/src/controllers/BillController.php
@@ -30,6 +30,7 @@ use hipanel\modules\finance\forms\BillForm;
 use hipanel\modules\finance\forms\BillImportForm;
 use hipanel\modules\finance\forms\CurrencyExchangeForm;
 use hipanel\modules\finance\helpers\ChargesGrouper;
+use hipanel\modules\finance\models\Bill;
 use hipanel\modules\finance\models\ExchangeRate;
 use hipanel\modules\finance\models\query\ChargeQuery;
 use hipanel\modules\finance\models\Resource;
@@ -104,8 +105,13 @@ class BillController extends CrudController
                         /** @var ActiveDataProvider $dataProvider */
                         $dataProvider = $action->parent->getDataProvider();
                         $altQuery = clone $dataProvider->query;
+                        /** @var ?Bill $lastModifiedBill */
                         $lastModifiedBill = $altQuery->where(['groupby' => 'last_modified'])->one();
-                        $key = serialize(array_merge($action->controller->request->get(null, []), [$this->user->getId(), $lastModifiedBill->ts]));
+
+                        $key = serialize(array_merge(
+                            $action->controller->request->get(null, []),
+                            [$this->user->getId(), $lastModifiedBill->ts ?? null],
+                        ));
 
                         return $this->cache->getOrSet($key, function () use ($action, $dataProvider): string {
                             $defaultSummary = (new SynchronousCountEnabler($dataProvider, fn(GridView $grid): string => $grid->renderSummary()))();

--- a/src/models/Bill.php
+++ b/src/models/Bill.php
@@ -31,6 +31,7 @@ use yii\helpers\StringHelper;
  * @property mixed|null $type_id
  * @property mixed|null $currency
  * @property float|mixed|null $sum
+ * @property string $ts
  */
 class Bill extends \hipanel\base\Model implements HasSumAndCurrencyAttributesInterface, HasTimeAttributeInterface
 {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d43dea97-c543-4446-bd13-8d8f5ef8917f)
https://sentry.hiqdev.com/organizations/hiqdev/issues/65114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cache key generation to handle cases where the last modified bill's timestamp may be missing, enhancing stability and reliability.

- **Documentation**
  - Updated documentation for the Bill model to clarify the presence and type of the timestamp attribute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->