### PR TITLE
HP-2875: add replacement part doc

### DIFF
--- a/src/actions/CreateFromPricesAction.php
+++ b/src/actions/CreateFromPricesAction.php
@@ -41,7 +41,7 @@ class CreateFromPricesAction extends BillManagementAction
             }
             $billTypes = $this->billTypesProvider->getTypes();
             $prices = Price::find()
-                ->select(['*', 'main_object_id', 'object'])
+                ->select(['*', 'main_object_id'])
                 ->joinWith(['object'])
                 ->withFormulaLines()
                 ->where(['id_in' => $priceIds])

--- a/src/grid/PurseGridView.php
+++ b/src/grid/PurseGridView.php
@@ -78,6 +78,10 @@ class PurseGridView extends BoxedGridView
                 'class' => MonthlyDocumentsColumn::class,
                 'type' => 'old_payment_plan_payment_request',
             ],
+            'replacementPartNotice' => [
+                'class' => MonthlyDocumentsColumn::class,
+                'type' => 'replacement_part_notice',
+            ],
             'acceptances' => [
                 'class' => MonthlyDocumentsColumn::class,
                 'type' => 'acceptance',

--- a/src/models/Purse.php
+++ b/src/models/Purse.php
@@ -164,6 +164,11 @@ class Purse extends \hipanel\base\Model
         return $this->getDocumentsOfType(Requisite::TEMPLATE_OLD_PAYMENT_PLAN_PAYMENT_REQUEST);
     }
 
+    public function getReplacementPartNotice(): array
+    {
+        return $this->getDocumentsOfType(Requisite::TEMPLATE_REPLACEMENT_PART_NOTICE);
+    }
+
     public function getDocumentsOfType($type): array
     {
         if (Yii::$app->user->can('document.read') === false) {

--- a/src/models/Requisite.php
+++ b/src/models/Requisite.php
@@ -59,6 +59,7 @@ class Requisite extends Contact
     const string TEMPLATE_DETAILED_PAYMENT_REQUEST = 'detailed_service_payment_request';
     const string TEMPLATE_PAYMENT_PLAN_PAYMENT_REQUEST = 'payment_plan_payment_request';
     const string TEMPLATE_OLD_PAYMENT_PLAN_PAYMENT_REQUEST = 'old_payment_plan_payment_request';
+    const string TEMPLATE_REPLACEMENT_PART_NOTICE = 'replacement_part_notice';
 
     public static function tableName()
     {
@@ -95,6 +96,7 @@ class Requisite extends Contact
                     'detailed_service_invoice_id',
                     'payment_plan_payment_request_id',
                     'old_payment_plan_payment_request_id',
+                    'replacement_part_notice_id',
                     'nda_id',
                 ],
                 'string', // template2pdf ID
@@ -118,6 +120,7 @@ class Requisite extends Contact
                     'old_payment_plan_payment_request_name',
                     'detailed_service_payment_request_name',
                     'detailed_service_invoice_name',
+                    'replacement_part_notice_name',
                     'nda_name',
                 ],
                 'string',
@@ -200,6 +203,7 @@ class Requisite extends Contact
             self::TEMPLATE_DETAILED_SERVICE_INVOICE => self::TEMPLATE_DETAILED_SERVICE_INVOICE,
             self::TEMPLATE_DETAILED_PAYMENT_REQUEST => self::TEMPLATE_DETAILED_PAYMENT_REQUEST,
             self::TEMPLATE_PAYMENT_PLAN_PAYMENT_REQUEST => self::TEMPLATE_PAYMENT_PLAN_PAYMENT_REQUEST,
+            self::TEMPLATE_REPLACEMENT_PART_NOTICE => self::TEMPLATE_REPLACEMENT_PART_NOTICE,
         ];
     }
 

--- a/src/views/purse/_client-view.php
+++ b/src/views/purse/_client-view.php
@@ -19,7 +19,7 @@ if ($user->can('document.read') && $user->can('bill.read')) {
     $documents = ($isEmployee ? ['acceptances'] : [
         'serviceInvoices', 'purchaseInvoices', 'installmentInvoices', 'oldInstallmentInvoices',
         'servicePaymentRequests', 'purchasePaymentRequests', 'installmentPaymentRequests',
-        'paymentplanPaymentRequests', 'oldPaymentplanPaymentRequests',
+        'paymentplanPaymentRequests', 'oldPaymentplanPaymentRequests', 'replacementPartNotice',
     ]);
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Replacement Part Notice" as a new document type in the purse system.
  * Replacement Part Notices now appear in purse lists and client views alongside other documents.
  * A new column was added to grid views so Replacement Part Notices are visible in tabular displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->