### PR TITLE
HQD-176: Fix /finance/bill/generate-invoice PDF preview

### DIFF
--- a/src/actions/GenerateInvoiceAction.php
+++ b/src/actions/GenerateInvoiceAction.php
@@ -49,11 +49,7 @@ class GenerateInvoiceAction extends BillManagementAction
                 $generateInvoiceForm->data = json_decode($generateInvoiceForm->data, true, 512, JSON_THROW_ON_ERROR);
                 $response = Document::perform('generate', $generateInvoiceForm->attributes);
 
-                return $this->controller->response->sendContentAsFile(
-                    $response,
-                    $generateInvoiceForm->filename,
-                    ['inline' => true, 'mimeType' => 'application/pdf']
-                );
+                return $this->controller->redirect(['@document/get-cached-file', 'uuid' => $response['uuid']]);
             }
             $billIds = $this->controller->request->post('selection', []);
             $bills = $this->getBills($billIds);

--- a/src/views/bill/generate-invoice.php
+++ b/src/views/bill/generate-invoice.php
@@ -76,7 +76,7 @@ $this->params['breadcrumbs'][] = $this->title;
                         <div class="form-group">
                             <label for="number">Document number</label>
                             <input type="text" class="form-control" id="number"
-                                   v-model="invoice.data.monthly_invoice.number">
+                                   v-model="invoice.data.monthly_document.number">
                         </div>
                         <div class="form-group">
                             <label for="vat_number">VAT Number</label>
@@ -99,7 +99,7 @@ $this->params['breadcrumbs'][] = $this->title;
 
             </div>
 
-            <div class="box-footer" v-for="(item, idx) in invoice.data.monthly_invoice.items" :key="idx">
+            <div class="box-footer" v-for="(item, idx) in invoice.data.monthly_document.items" :key="idx">
                 <div class="row">
 
                     <div class="form-group col-md-9">
@@ -116,14 +116,14 @@ $this->params['breadcrumbs'][] = $this->title;
 
             <div class="box-footer">
                 <dl class="dl-horizontal pull-right">
-                    <dt>Total for {{ invoice.data.monthly_invoice.period.month }} {{
-                        invoice.data.monthly_invoice.period.year }}
+                    <dt>Total for {{ invoice.data.monthly_document.period.month }} {{
+                        invoice.data.monthly_document.period.year }}
                     </dt>
-                    <dd>{{ invoice.data.monthly_invoice.subtotal }}</dd>
+                    <dd>{{ invoice.data.monthly_document.subtotal }}</dd>
                     <dt>Tax (VAT {{ invoice.data.vat_rate }}%)</dt>
-                    <dd>{{ invoice.data.monthly_invoice.tax_value }}</dd>
+                    <dd>{{ invoice.data.monthly_document.tax_value }}</dd>
                     <dt>TOTAL</dt>
-                    <dd>{{ invoice.data.monthly_invoice.final_total }}</dd>
+                    <dd>{{ invoice.data.monthly_document.final_total }}</dd>
                 </dl>
             </div>
 


### PR DESCRIPTION
  _documentGenerate now returns {uuid, url, requisite} via
  DocumentPreviewCache instead of raw binary for save=false.
  Two fixes:
  - GenerateInvoiceAction: redirect to @document/get-cached-file instead of trying to stream an array as file content
  - generate-invoice.php: rename monthly_invoice → monthly_document to match the key name returned by _documentPrepareInvoice, fixing Vue render error "Cannot read properties of undefined"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Invoice PDF generation now retrieves cached document files using unique identifiers rather than serving PDFs as direct downloads.
  * Invoice display template restructured to access updated data fields for document numbers, itemized line items, and comprehensive financial summaries including period details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiqdev/hipanel-module-finance/pull/598?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->