### PR TITLE
HQD-178: fix synchronize bill datetime with charges

### DIFF
--- a/src/views/bill/_form.php
+++ b/src/views/bill/_form.php
@@ -48,7 +48,6 @@ $this->registerCss("
   margin-right: -10px;
   margin-left: -10px;
 }
-
 ");
 
 $form = ActiveForm::begin([
@@ -61,6 +60,7 @@ $form = ActiveForm::begin([
         'scenario' => $model->scenario,
     ]),
 ]) ?>
+
 <?php DynamicFormWidget::begin([
     'widgetContainer' => 'bills_dynamicform_wrapper', // required: only alphanumeric characters plus "_" [A-Za-z0-9_]
     'widgetBody' => '.container-items', // required: css class selector
@@ -163,7 +163,12 @@ $form = ActiveForm::begin([
                             <?= $form->field($model, "[$i]label") ?>
                         </div>
                         <div class="col-md-3">
-                            <?= $form->field($model, "[$i]time")->widget(DateTimePickerWithFormatter::class) ?>
+                            <?= $form->field($model, "[$i]time")->widget(
+                                DateTimePickerWithFormatter::class,
+                                [
+                                    'options' => ['class' => 'bill-time']
+                                ]
+                            ) ?>
                         </div>
                     </div>
 

--- a/src/widgets/UpdateChargeTimeScript.php
+++ b/src/widgets/UpdateChargeTimeScript.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace hipanel\modules\finance\widgets;
 


### PR DESCRIPTION
Corrects a bug where the bill datetime input field in the create bill form was not synchronizing with the datetime in the charges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual styling of the bill time input field for improved form presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiqdev/hipanel-module-finance/pull/599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->