### PR TITLE
HQD-137: add currency totals summary to Installment Plans index page

### DIFF
--- a/src/controllers/InstallmentPlanController.php
+++ b/src/controllers/InstallmentPlanController.php
@@ -13,11 +13,15 @@ namespace hipanel\modules\finance\controllers;
 use hipanel\actions\IndexAction;
 use hipanel\actions\SmartDeleteAction;
 use hipanel\actions\SmartPerformAction;
+use hipanel\actions\VariantsAction;
 use hipanel\actions\ViewAction;
 use hipanel\filters\EasyAccessControl;
 use hipanel\modules\finance\actions\InstallmentPlanCreateBillAction;
 use hipanel\modules\finance\actions\InstallmentPlanProcessAction;
 use hipanel\modules\finance\models\InstallmentPlan;
+use hipanel\modules\finance\widgets\InstallmentPlanSummaryTable;
+use hipanel\widgets\DataProviderGridRenderer;
+use hiqdev\hiart\ActiveDataProvider;
 use Yii;
 use yii\data\ArrayDataProvider;
 
@@ -44,6 +48,19 @@ class InstallmentPlanController extends \hipanel\base\CrudController
         return array_merge(parent::actions(), [
             'index' => [
                 'class' => IndexAction::class,
+                'responseVariants' => [
+                    IndexAction::VARIANT_SUMMARY_RESPONSE => function (VariantsAction $action): string {
+                        /** @var ActiveDataProvider $dataProvider */
+                        $dataProvider = $action->parent->getDataProvider();
+                        $defaultSummary = (new DataProviderGridRenderer($dataProvider))->renderSummary();
+                        $installmentPlansSummary = InstallmentPlanSummaryTable::widget([
+                            'currencies' => $action->controller->getCurrencyTypes(),
+                            'allModels'  => $dataProvider->query->andWhere(['groupby' => 'sum_by_currency'])->all(),
+                        ]);
+
+                        return $defaultSummary . $installmentPlansSummary;
+                    },
+                ],
             ],
             'delete' => [
                 'class' => SmartDeleteAction::class,

--- a/src/widgets/InstallmentPlanSummaryTable.php
+++ b/src/widgets/InstallmentPlanSummaryTable.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace hipanel\modules\finance\widgets;
+
+use Yii;
+use yii\helpers\Html;
+
+class InstallmentPlanSummaryTable extends FinanceSummaryTable
+{
+    public function init(): void
+    {
+        parent::init();
+
+        $this->tableName = empty($this->onPageModels) ? Yii::t('hipanel:finance', 'Summary') : Yii::t('hipanel:finance', 'Page summary');
+        $this->rows = [
+            'expected_sum'         => Yii::t('hipanel:finance', 'Total sum'),
+            'expected_monthly_sum' => Yii::t('hipanel:finance', 'Monthly sum'),
+            'charged_sum'          => Yii::t('hipanel:finance', 'Charged sum'),
+            'left_sum'             => Yii::t('hipanel:finance', 'Left sum'),
+        ];
+        $this->displayModels = empty($this->onPageModels) ? $this->allModels : $this->onPageModels;
+    }
+
+    public function run(): string
+    {
+        if (empty($this->displayModels)) {
+            return Html::tag('div', '', ['class' => 'summary']);
+        }
+
+        $values = $this->calculate();
+
+        return $this->render('FinanceSummaryTable', [
+            'currencies' => $this->filterCurrencies($values),
+            'tableName'  => $this->tableName,
+            'rows'       => $this->rows,
+            'values'     => $values,
+        ]);
+    }
+
+    protected function calculate(): array
+    {
+        $expectedSum = $expectedMonthlySum = $chargedSum = $leftSum = [];
+
+        foreach ($this->displayModels as $row) {
+            $currency = $row->currency;
+            $expectedSum[$currency]        = (float)$row->expected_sum;
+            $expectedMonthlySum[$currency] = (float)$row->expected_monthly_sum;
+            $chargedSum[$currency]         = (float)$row->charged_sum;
+            $leftSum[$currency]            = (float)$row->left_sum;
+        }
+
+        return [
+            'expected_sum'         => $expectedSum,
+            'expected_monthly_sum' => $expectedMonthlySum,
+            'charged_sum'          => $chargedSum,
+            'left_sum'             => $leftSum,
+        ];
+    }
+}


### PR DESCRIPTION
Adds a per-currency totals table at the bottom of the installment plans index page, similar to Bills. InstallmentPlanSummaryTable renders sums of expected_sum, expected_monthly_sum, charged_sum, left_sum per currency via a separate groupby=sum_by_currency request to HiAPI.