### PR TITLE
HQD-250 Register BillPreloadStorage in DI container singletons

### DIFF
--- a/config/web.php
+++ b/config/web.php
@@ -176,6 +176,7 @@ return [
         ],
         'singletons' => [
             hipanel\modules\finance\providers\BillTypesProvider::class => hipanel\modules\finance\providers\BillTypesProvider::class,
+            hipanel\modules\finance\providers\BillPreloadStorage::class => hipanel\modules\finance\providers\BillPreloadStorage::class,
             hiqdev\yii2\merchant\transactions\TransactionRepositoryInterface::class => hipanel\modules\finance\transaction\ApiTransactionRepository::class,
             hipanel\modules\finance\logic\bill\QuantityFormatterFactoryInterface::class => hipanel\modules\finance\logic\bill\QuantityFormatterFactory::class,
             hipanel\modules\finance\models\ServerResourceTypesProviderInterface::class => hipanel\modules\finance\models\ServerResourceTypesProvider::class,


### PR DESCRIPTION
## Description
Fixes HTTP 500 error (`Could not load required service: preloadStorage`) when opening `/finance/bill/import` or using preloaded bills.

## Root Cause
`BillController::actionImport(BillPreloadStorage $preloadStorage)` receives `BillPreloadStorage` via action parameter injection. However, `BillPreloadStorage` was missing from `config/web.php` container singletons, causing Yii container parameter resolution to fail with an exception.

## Fix
Registered `\hipanel\modules\finance\providers\BillPreloadStorage::class` in `config/web.php` singletons configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved the reliability of bill data preloading across the finance module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->