### PR TITLE
HQD-288: fix TypeError on generate-invoice caused by BillManagementAction constructor mismatch

### DIFF
--- a/src/actions/BillImportFromFileAction.php
+++ b/src/actions/BillImportFromFileAction.php
@@ -9,6 +9,7 @@ use hipanel\modules\finance\forms\BillForm;
 use hipanel\modules\finance\forms\BillImportFromFileForm;
 use hipanel\modules\finance\helpers\parser\BillsImporter;
 use hipanel\modules\finance\helpers\parser\NoParserAppropriateType;
+use hipanel\modules\finance\providers\BillPreloadStorage;
 use hipanel\modules\finance\providers\BillTypesProvider;
 use RuntimeException;
 use Yii;
@@ -22,9 +23,9 @@ class BillImportFromFileAction extends BillManagementAction
 {
     private Session $session;
 
-    public function __construct($id, Controller $controller, BillTypesProvider $billTypesProvider, Session $session, array $config = [])
+    public function __construct($id, Controller $controller, BillTypesProvider $billTypesProvider, BillPreloadStorage $preloadStorage, Session $session, array $config = [])
     {
-        parent::__construct($id, $controller, $billTypesProvider, $config);
+        parent::__construct($id, $controller, $billTypesProvider, $preloadStorage, $config);
         $this->session = $session;
     }
 

--- a/src/actions/CreateFromPricesAction.php
+++ b/src/actions/CreateFromPricesAction.php
@@ -11,6 +11,7 @@ use hipanel\modules\finance\helpers\LightPriceChargesEstimator;
 use hipanel\modules\finance\models\Plan;
 use hipanel\modules\finance\models\Price;
 use hipanel\modules\finance\models\Sale;
+use hipanel\modules\finance\providers\BillPreloadStorage;
 use hipanel\modules\finance\providers\BillTypesProvider;
 use Yii;
 use yii\web\BadRequestHttpException;
@@ -25,9 +26,9 @@ class CreateFromPricesAction extends BillManagementAction
 
     private Session $session;
 
-    public function __construct($id, Controller $controller, BillTypesProvider $billTypesProvider, Session $session, array $config = [])
+    public function __construct($id, Controller $controller, BillTypesProvider $billTypesProvider, BillPreloadStorage $preloadStorage, Session $session, array $config = [])
     {
-        parent::__construct($id, $controller, $billTypesProvider, $config);
+        parent::__construct($id, $controller, $billTypesProvider, $preloadStorage, $config);
         $this->session = $session;
     }
 

--- a/src/actions/GenerateInvoiceAction.php
+++ b/src/actions/GenerateInvoiceAction.php
@@ -10,6 +10,7 @@ use hipanel\modules\document\models\Document;
 use hipanel\modules\finance\forms\GenerateInvoiceForm;
 use hipanel\modules\finance\forms\PrepareInvoiceForm;
 use hipanel\modules\finance\models\Bill;
+use hipanel\modules\finance\providers\BillPreloadStorage;
 use hipanel\modules\finance\providers\BillTypesProvider;
 use yii\web\BadRequestHttpException;
 use yii\web\Controller;
@@ -22,9 +23,9 @@ class GenerateInvoiceAction extends BillManagementAction
 {
     private Session $session;
 
-    public function __construct($id, Controller $controller, BillTypesProvider $billTypesProvider, Session $session, array $config = [])
+    public function __construct($id, Controller $controller, BillTypesProvider $billTypesProvider, BillPreloadStorage $preloadStorage, Session $session, array $config = [])
     {
-        parent::__construct($id, $controller, $billTypesProvider, $config);
+        parent::__construct($id, $controller, $billTypesProvider, $preloadStorage, $config);
         $this->session = $session;
     }
 


### PR DESCRIPTION
GenerateInvoiceAction, BillImportFromFileAction, and CreateFromPricesAction were still calling the old 4-arg BillManagementAction::__construct(), so $config landed in the BillPreloadStorage positional slot and threw a TypeError on every request. Inject BillPreloadStorage in each subclass and pass it through to the parent constructor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the billing workflow’s preparation and data-handling infrastructure.
  * Updated invoice generation, bill importing, and price-based bill creation to use shared preloading support.
  * No changes to the visible interface or user-facing functionality are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->