### PR TITLE
HQD-170: Redesign on-demand document page into two labeled sections, …

### DIFF
--- a/src/actions/GenerateOnDemandDocumentAction.php
+++ b/src/actions/GenerateOnDemandDocumentAction.php
@@ -66,7 +66,7 @@ class GenerateOnDemandDocumentAction extends Action
             return $this->controller->redirect(['index']);
         }
 
-        $charges = Charge::find()->where(['bill_ids' => $billIds])->withIncludedInDocuments()->all();
+        $charges = Charge::find()->where(['bill_ids' => $billIds, 'limit' => 'ALL'])->withIncludedInDocuments()->all();
 
         $chargeGroups = [];
         foreach ($charges as $charge) {

--- a/src/actions/GenerateOnDemandDocumentAction.php
+++ b/src/actions/GenerateOnDemandDocumentAction.php
@@ -66,7 +66,7 @@ class GenerateOnDemandDocumentAction extends Action
             return $this->controller->redirect(['index']);
         }
 
-        $charges = Charge::find()->where(['bill_ids' => $billIds, 'limit' => 'ALL'])->withIncludedInDocuments()->all();
+        $charges = Charge::find()->where(['bill_ids' => $billIds])->withIncludedInDocuments()->limit(-1)->all();
 
         $chargeGroups = [];
         foreach ($charges as $charge) {

--- a/src/actions/GenerateOnDemandDocumentFromChargesAction.php
+++ b/src/actions/GenerateOnDemandDocumentFromChargesAction.php
@@ -58,7 +58,7 @@ class GenerateOnDemandDocumentFromChargesAction extends Action
             return $this->controller->redirect(['index']);
         }
 
-        $charges = Charge::find()->where(['ids' => $chargeIds, 'limit' => 'ALL'])->withIncludedInDocuments()->all();
+        $charges = Charge::find()->where(['ids' => $chargeIds])->withIncludedInDocuments()->limit(-1)->all();
 
         $chargeGroups = [];
         foreach ($charges as $charge) {

--- a/src/actions/GenerateOnDemandDocumentFromChargesAction.php
+++ b/src/actions/GenerateOnDemandDocumentFromChargesAction.php
@@ -58,7 +58,7 @@ class GenerateOnDemandDocumentFromChargesAction extends Action
             return $this->controller->redirect(['index']);
         }
 
-        $charges = Charge::find()->where(['ids' => $chargeIds])->withIncludedInDocuments()->all();
+        $charges = Charge::find()->where(['ids' => $chargeIds, 'limit' => 'ALL'])->withIncludedInDocuments()->all();
 
         $chargeGroups = [];
         foreach ($charges as $charge) {

--- a/src/assets/GenerateOnDemandDocumentAsset/generate-on-demand-document-app.js
+++ b/src/assets/GenerateOnDemandDocumentAsset/generate-on-demand-document-app.js
@@ -87,6 +87,7 @@ Vue.createApp({
       }
 
       this.groupsWithState = [];
+      this.wasPrepared = false;
       this._highlightIneligible([]);
       this.allSaved = false;
       this.makeRequest(this.prepareUrl, postData.toString(), (data) => {

--- a/src/assets/GenerateOnDemandDocumentAsset/generate-on-demand-document-app.js
+++ b/src/assets/GenerateOnDemandDocumentAsset/generate-on-demand-document-app.js
@@ -15,7 +15,8 @@ Vue.createApp({
     ).forEach((el) => {
       el.addEventListener("change", () => {
         this.groupsWithState = [];
-        this.ineligibleChargeIds = [];
+        this.wasPrepared = false;
+        this._highlightIneligible([]);
       });
     });
   },
@@ -33,16 +34,38 @@ Vue.createApp({
   },
   data() {
     return {
-      groupsWithState:    [],
-      ineligibleChargeIds: [],
-      isLoading: false,
+      groupsWithState: [],
+      wasPrepared: false,
+      isLoading:   false,
       isSavingAll: false,
-      allSaved: false,
+      allSaved:    false,
       type: null,
       date: null,
     };
   },
   methods: {
+    _highlightIneligible(ineligibleIds) {
+      const ineligibleSet = new Set(ineligibleIds);
+
+      document.querySelectorAll("tr[data-charge-id]").forEach((row) => {
+        const id = Number(row.dataset.chargeId);
+        const isIneligible = ineligibleSet.has(id);
+        row.querySelectorAll("td").forEach((td) => {
+          td.style.backgroundColor = isIneligible ? "#ffaa44" : "";
+        });
+      });
+
+      document.querySelectorAll(".box.box-widget").forEach((box) => {
+        const rows = [...box.querySelectorAll("tr[data-charge-id]")];
+        if (rows.length === 0) return;
+        const allIneligible = rows.every((row) => ineligibleSet.has(Number(row.dataset.chargeId)));
+        const header = box.querySelector(".box-header");
+        if (header) {
+          header.style.backgroundColor = allIneligible ? "#ffaa44" : "#d2e8f5";
+        }
+      });
+    },
+
     prepareDocument() {
       this.type = document.querySelector('[name="PrepareOnDemandDocumentForm[type]"]')?.value || null;
       this.date = document.querySelector('[name="PrepareOnDemandDocumentForm[date]"]')?.value || null;
@@ -64,7 +87,7 @@ Vue.createApp({
       }
 
       this.groupsWithState = [];
-      this.ineligibleChargeIds = [];
+      this._highlightIneligible([]);
       this.allSaved = false;
       this.makeRequest(this.prepareUrl, postData.toString(), (data) => {
         const entries = Object.entries(data);
@@ -85,15 +108,13 @@ Vue.createApp({
             documentUrl: null,
           }));
 
-        if (this.groupsWithState.length === 0) {
-          hipanel.notify.info("No eligible charges found for the selected items.");
-        }
-
         const eligibleIds = new Set();
         entries.filter(([, g]) => !g._error).forEach(([, group]) => {
           (group.charges || []).forEach((c) => eligibleIds.add(Number(c.id)));
         });
-        this.ineligibleChargeIds = this.parsedChargeIds.filter((id) => !eligibleIds.has(id));
+        const ineligibleIds = this.parsedChargeIds.filter((id) => !eligibleIds.has(id));
+        this._highlightIneligible(ineligibleIds);
+        this.wasPrepared = true;
       });
     },
 
@@ -151,6 +172,10 @@ Vue.createApp({
           resolve();
         });
       });
+    },
+
+    stripTags(value) {
+      return value ? String(value).replace(/<[^>]*>/g, "") : "";
     },
 
     formatSum(sum, currency) {

--- a/src/grid/ChargeGridView.php
+++ b/src/grid/ChargeGridView.php
@@ -134,6 +134,8 @@ class ChargeGridView extends BoxedGridView
 
                     if ($model->isRelationPopulated('commonObject')
                         && $model->isRelationPopulated('latestCommonObject')
+                        && $model->commonObject !== null
+                        && $model->latestCommonObject !== null
                         && $model->commonObject->id !== null
                         && $model->commonObject->id !== $model->latestCommonObject->id) {
                         $result .= ' ' . Html::tag(

--- a/src/grid/ChargeGridView.php
+++ b/src/grid/ChargeGridView.php
@@ -132,7 +132,10 @@ class ChargeGridView extends BoxedGridView
                             'labelAttribute' => 'name',
                         ]) . ($model->label ? " &ndash; $model->label" : '');
 
-                    if ($model->commonObject->id !== null && $model->commonObject->id !== $model->latestCommonObject->id) {
+                    if ($model->isRelationPopulated('commonObject')
+                        && $model->isRelationPopulated('latestCommonObject')
+                        && $model->commonObject->id !== null
+                        && $model->commonObject->id !== $model->latestCommonObject->id) {
                         $result .= ' ' . Html::tag(
                                 'span',
                                 Yii::t('hipanel:finance', 'Now it is in {objectLink}', [

--- a/src/messages/ru/hipanel:finance.php
+++ b/src/messages/ru/hipanel:finance.php
@@ -356,4 +356,27 @@ return [
     'Manufacturer' => 'Производитель',
     'Company' => 'Компания',
     'Order' => 'Заказ',
+
+    'Leave blank to use today\'s date' => 'Оставьте пустым, чтобы использовать сегодняшнюю дату',
+
+    // On-demand document generation
+    'Generate on-demand document'       => 'Генерация документа по запросу',
+    'Document type'                     => 'Тип документа',
+    'Prepare document'                  => 'Подготовить документ',
+    'Selected charges'                  => 'Выбранные списания',
+    'Charges for document generation'   => 'Списания для генерации документа',
+    'Generate & Save'                   => 'Создать и сохранить',
+    'Saved'                             => 'Сохранено',
+    'View document'                     => 'Просмотреть документ',
+    'Preview'                           => 'Предпросмотр',
+    'available'                         => 'доступно',
+    'already in documents'              => 'уже в документах',
+    'Already in documents'              => 'Уже в документах',
+    'charge(s)'                         => 'списание(й)',
+    'None of the selected charges are eligible for the chosen document type and date.' => 'Ни одно из выбранных списаний не подходит для выбранного типа документа и даты.',
+    'Payment request'                   => 'Запрос на оплату',
+    'Service invoice'                   => 'Инвойс за услуги',
+    'Purchase invoice'                  => 'Инвойс за покупку',
+    'Installment invoice'               => 'Инвойс по рассрочке',
+    'Payment plan'                      => 'Платёжный план',
 ];

--- a/src/widgets/views/generate-on-demand-document.php
+++ b/src/widgets/views/generate-on-demand-document.php
@@ -47,6 +47,7 @@ foreach ($chargeGroups as $group) {
         'enableAjaxValidation'   => false,
     ]) ?>
 
+    <?php /* Form controls */ ?>
     <div class="col-md-12">
         <div class="box box-widget">
             <div class="box-body">
@@ -57,7 +58,7 @@ foreach ($chargeGroups as $group) {
                     <div class="col-sm-3">
                         <?= $form->field($model, 'date')->widget(DatePicker::class, [
                             'clientOptions' => ['maxDate' => 'today'],
-                        ])->hint(Yii::t('hipanel:finance', 'Leave blank to use the last closed month')) ?>
+                        ])->hint(Yii::t('hipanel:finance', 'Leave blank to use today\'s date')) ?>
                     </div>
                     <div class="col-sm-5 text-right" style="padding-top: 25px">
                         <button type="button" class="btn btn-primary" @click="prepareDocument" :disabled="isLoading">
@@ -70,133 +71,157 @@ foreach ($chargeGroups as $group) {
         </div>
     </div>
 
-    <?php foreach ($chargeGroups as $group):
-        $available   = array_values(array_filter($group['charges'], static fn($c) => empty($c->included_in_documents)));
-        $inDocuments = array_values(array_filter($group['charges'], static fn($c) => !empty($c->included_in_documents)));
-    ?>
+    <?php /* Section: selected charges */ ?>
     <div class="col-md-12">
-        <div class="box box-widget">
+        <div class="box box-default">
             <div class="box-header with-border">
-                <h3 class="box-title">
-                    <?= Html::encode($group['client']) ?> &mdash; <?= Html::encode($group['currency']) ?>
-                    <small class="text-muted">
-                        (<?= count($available) ?> <?= Yii::t('hipanel:finance', 'available') ?><?php if ($inDocuments): ?>,
-                        <?= count($inDocuments) ?> <?= Yii::t('hipanel:finance', 'already in documents') ?><?php endif ?>)
-                    </small>
-                </h3>
+                <h3 class="box-title"><?= Yii::t('hipanel:finance', 'Selected charges') ?></h3>
             </div>
-            <?php if (!empty($available)): ?>
-            <div class="box-body no-padding">
-                <table class="table table-condensed table-striped">
-                    <thead>
-                        <tr>
-                            <th><?= Yii::t('hipanel:finance', 'Type') ?></th>
-                            <th><?= Yii::t('hipanel:finance', 'Description') ?></th>
-                            <th><?= Yii::t('hipanel:finance', 'Qty') ?></th>
-                            <th><?= Yii::t('hipanel:finance', 'Unit') ?></th>
-                            <th><?= Yii::t('hipanel:finance', 'Date') ?></th>
-                            <th class="text-right"><?= Yii::t('hipanel:finance', 'Sum') ?></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <?php foreach ($available as $charge): ?>
-                        <tr :class="{ warning: ineligibleChargeIds.includes(<?= (int) $charge->id ?>) }">
-                            <td><?= Html::encode($charge->type) ?></td>
-                            <td><?= Html::encode($charge->name ?? '') ?></td>
-                            <td><?= Html::encode($charge->quantity ?? '') ?></td>
-                            <td><?= Html::encode($charge->unit ?? '') ?></td>
-                            <td><?= Html::encode($charge->time ?? '') ?></td>
-                            <td class="text-right"><?= Html::encode($charge->sum ?? '') ?></td>
-                        </tr>
-                        <?php endforeach ?>
-                    </tbody>
-                </table>
+            <div class="box-body" style="padding: 10px 10px 0;">
+
+                <?php foreach ($chargeGroups as $group):
+                    $available   = array_values(array_filter($group['charges'], static fn($c) => empty($c->included_in_documents)));
+                    $inDocuments = array_values(array_filter($group['charges'], static fn($c) => !empty($c->included_in_documents)));
+                ?>
+                <div class="box box-widget">
+                    <div class="box-header with-border" style="background-color: #d2e8f5;">
+                        <h3 class="box-title">
+                            <?= Html::encode($group['client']) ?> &mdash; <?= Html::encode($group['currency']) ?>
+                            <small class="text-muted">
+                                (<?= count($available) ?> <?= Yii::t('hipanel:finance', 'available') ?><?php if ($inDocuments): ?>,
+                                <?= count($inDocuments) ?> <?= Yii::t('hipanel:finance', 'already in documents') ?><?php endif ?>)
+                            </small>
+                        </h3>
+                    </div>
+                    <?php if (!empty($available)): ?>
+                    <div class="box-body no-padding">
+                        <table class="table table-condensed table-striped">
+                            <thead>
+                                <tr>
+                                    <th><?= Yii::t('hipanel:finance', 'Type') ?></th>
+                                    <th><?= Yii::t('hipanel:finance', 'Description') ?></th>
+                                    <th><?= Yii::t('hipanel:finance', 'Qty') ?></th>
+                                    <th><?= Yii::t('hipanel:finance', 'Unit') ?></th>
+                                    <th><?= Yii::t('hipanel:finance', 'Date') ?></th>
+                                    <th class="text-right"><?= Yii::t('hipanel:finance', 'Sum') ?></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <?php foreach ($available as $charge): ?>
+                                <tr data-charge-id="<?= (int) $charge->id ?>">
+                                    <td><?= Html::encode($charge->type) ?></td>
+                                    <td><?= Html::encode($charge->label ?? '') ?></td>
+                                    <td><?= Html::encode($charge->quantity ?? '') ?></td>
+                                    <td><?= Html::encode($charge->unit ?? '') ?></td>
+                                    <td><?= Html::encode($charge->time ?? '') ?></td>
+                                    <td class="text-right"><?= Html::encode($charge->sum ?? '') ?></td>
+                                </tr>
+                                <?php endforeach ?>
+                            </tbody>
+                        </table>
+                    </div>
+                    <?php endif ?>
+                    <?php if (!empty($inDocuments)): ?>
+                    <div class="box-header" style="background:#fcfcfc; border-top:1px solid #f0f0f0">
+                        <h4 class="box-title text-muted" style="font-size:13px">
+                            <?= Yii::t('hipanel:finance', 'Already in documents') ?>
+                        </h4>
+                    </div>
+                    <div class="box-body no-padding">
+                        <table class="table table-condensed" style="opacity:.55">
+                            <tbody>
+                                <?php foreach ($inDocuments as $charge): ?>
+                                <tr>
+                                    <td><?= Html::encode($charge->type) ?></td>
+                                    <td><?= Html::encode($charge->label ?? '') ?></td>
+                                    <td><?= Html::encode($charge->quantity ?? '') ?></td>
+                                    <td><?= Html::encode($charge->unit ?? '') ?></td>
+                                    <td><?= Html::encode($charge->time ?? '') ?></td>
+                                    <td class="text-right"><?= Html::encode($charge->sum ?? '') ?></td>
+                                </tr>
+                                <?php endforeach ?>
+                            </tbody>
+                        </table>
+                    </div>
+                    <?php endif ?>
+                </div>
+                <?php endforeach ?>
+
             </div>
-            <?php endif ?>
-            <?php if (!empty($inDocuments)): ?>
-            <div class="box-header" style="background:#fcfcfc; border-top:1px solid #f0f0f0">
-                <h4 class="box-title text-muted" style="font-size:13px">
-                    <?= Yii::t('hipanel:finance', 'Already in documents') ?>
-                </h4>
-            </div>
-            <div class="box-body no-padding">
-                <table class="table table-condensed" style="opacity:.55">
-                    <tbody>
-                        <?php foreach ($inDocuments as $charge): ?>
-                        <tr>
-                            <td><?= Html::encode($charge->type) ?></td>
-                            <td><?= Html::encode($charge->name ?? '') ?></td>
-                            <td><?= Html::encode($charge->quantity ?? '') ?></td>
-                            <td><?= Html::encode($charge->unit ?? '') ?></td>
-                            <td><?= Html::encode($charge->time ?? '') ?></td>
-                            <td class="text-right"><?= Html::encode($charge->sum ?? '') ?></td>
-                        </tr>
-                        <?php endforeach ?>
-                    </tbody>
-                </table>
-            </div>
-            <?php endif ?>
         </div>
     </div>
-    <?php endforeach ?>
 
     <?php ActiveForm::end() ?>
 
-    <div class="col-md-12" v-if="isPrepared">
-        <div v-for="group in groupsWithState" :key="group.groupKey" class="box box-widget">
-            <div class="box-header with-border">
-                <h3 class="box-title">
-                    {{ group.purse.client }}
-                    &mdash; {{ group.purse.currency }}
-                    <span v-if="group.location"> &mdash; {{ group.location }}</span>
-                    &mdash; {{ group.charges.length }} <?= Yii::t('hipanel:finance', 'charge(s)') ?>
-                    <small class="text-muted">#{{ group.purseId }}</small>
-                </h3>
-            </div>
-            <div class="box-body no-padding">
-                <table class="table table-condensed table-striped">
-                    <thead>
-                        <tr>
-                            <th><?= Yii::t('hipanel:finance', 'Type') ?></th>
-                            <th><?= Yii::t('hipanel:finance', 'Description') ?></th>
-                            <th><?= Yii::t('hipanel:finance', 'Qty') ?></th>
-                            <th><?= Yii::t('hipanel:finance', 'Unit') ?></th>
-                            <th><?= Yii::t('hipanel:finance', 'Date') ?></th>
-                            <th class="text-right"><?= Yii::t('hipanel:finance', 'Sum') ?></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr v-for="charge in group.charges" :key="charge.id">
-                            <td>{{ charge.type_label || charge.type }}</td>
-                            <td>{{ charge.description }}</td>
-                            <td>{{ charge.quantity }}</td>
-                            <td>{{ charge.unit }}</td>
-                            <td>{{ charge.time }}</td>
-                            <td class="text-right">{{ formatSum(charge.sum, group.purse.currency) }}</td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            <div class="box-footer clearfix">
-                <a v-if="group.documentUrl"
-                   :href="group.documentUrl"
-                   target="_blank"
-                   class="btn btn-default pull-left">
-                    <?= Yii::t('hipanel:finance', 'View document') ?>
-                </a>
-                <div class="pull-right">
-                    <button type="button"
-                            class="btn btn-default"
-                            :disabled="group.previewing || isSavingAll"
-                            @click="previewGroup(group)">
-                        <i v-if="group.previewing" class="fa fa-spin fa-spinner"></i>
-                        <?= Yii::t('hipanel:finance', 'Preview') ?>
-                    </button>
-                </div>
-            </div>
+    <?php /* Section: charges eligible for generation */ ?>
+    <div class="col-md-12" v-if="wasPrepared && !isPrepared">
+        <div class="alert alert-warning">
+            <i class="fa fa-exclamation-triangle"></i>
+            <?= Yii::t('hipanel:finance', 'None of the selected charges are eligible for the chosen document type and date.') ?>
         </div>
+    </div>
 
-        <div class="box box-widget">
+    <div class="col-md-12" v-if="isPrepared && groupsWithState.length > 0">
+        <div class="box box-success">
+            <div class="box-header with-border">
+                <h3 class="box-title"><?= Yii::t('hipanel:finance', 'Charges for document generation') ?></h3>
+            </div>
+            <div class="box-body" style="padding: 10px 10px 0;">
+
+                <div v-for="group in groupsWithState" :key="group.groupKey" class="box box-widget">
+                    <div class="box-header with-border">
+                        <h3 class="box-title">
+                            {{ group.purse.client }}
+                            &mdash; {{ group.purse.currency }}
+                            <span v-if="group.location"> &mdash; {{ group.location }}</span>
+                            &mdash; {{ group.charges.length }} <?= Yii::t('hipanel:finance', 'charge(s)') ?>
+                            <small class="text-muted">#{{ group.purseId }}</small>
+                        </h3>
+                    </div>
+                    <div class="box-body no-padding">
+                        <table class="table table-condensed table-striped">
+                            <thead>
+                                <tr>
+                                    <th><?= Yii::t('hipanel:finance', 'Type') ?></th>
+                                    <th><?= Yii::t('hipanel:finance', 'Description') ?></th>
+                                    <th><?= Yii::t('hipanel:finance', 'Qty') ?></th>
+                                    <th><?= Yii::t('hipanel:finance', 'Unit') ?></th>
+                                    <th><?= Yii::t('hipanel:finance', 'Date') ?></th>
+                                    <th class="text-right"><?= Yii::t('hipanel:finance', 'Sum') ?></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr v-for="charge in group.charges" :key="charge.id">
+                                    <td>{{ charge.type_label || charge.type }}</td>
+                                    <td>{{ stripTags(charge.description) }}</td>
+                                    <td>{{ charge.quantity }}</td>
+                                    <td>{{ charge.unit }}</td>
+                                    <td>{{ charge.time }}</td>
+                                    <td class="text-right">{{ formatSum(charge.sum, group.purse.currency) }}</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="box-footer clearfix">
+                        <a v-if="group.documentUrl"
+                           :href="group.documentUrl"
+                           target="_blank"
+                           class="btn btn-default pull-left">
+                            <?= Yii::t('hipanel:finance', 'View document') ?>
+                        </a>
+                        <div class="pull-right">
+                            <button type="button"
+                                    class="btn btn-default"
+                                    :disabled="group.previewing || isSavingAll"
+                                    @click="previewGroup(group)">
+                                <i v-if="group.previewing" class="fa fa-spin fa-spinner"></i>
+                                <?= Yii::t('hipanel:finance', 'Preview') ?>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+            </div>
             <div class="box-footer clearfix">
                 <div class="pull-right">
                     <button type="button"

--- a/src/widgets/views/generate-on-demand-document.php
+++ b/src/widgets/views/generate-on-demand-document.php
@@ -86,7 +86,7 @@ foreach ($chargeGroups as $group) {
                 <div class="box box-widget">
                     <div class="box-header with-border" style="background-color: #d2e8f5;">
                         <h3 class="box-title">
-                            <?= Html::encode($group['client']) ?> &mdash; <?= Html::encode($group['currency']) ?>
+                            <strong><?= Html::encode($group['client']) ?></strong> &mdash; <?= Html::encode($group['currency']) ?>
                             <small class="text-muted">
                                 (<?= count($available) ?> <?= Yii::t('hipanel:finance', 'available') ?><?php if ($inDocuments): ?>,
                                 <?= count($inDocuments) ?> <?= Yii::t('hipanel:finance', 'already in documents') ?><?php endif ?>)
@@ -171,7 +171,7 @@ foreach ($chargeGroups as $group) {
                 <div v-for="group in groupsWithState" :key="group.groupKey" class="box box-widget">
                     <div class="box-header with-border">
                         <h3 class="box-title">
-                            {{ group.purse.client }}
+                            <strong>{{ group.purse.client }}</strong>
                             &mdash; {{ group.purse.currency }}
                             <span v-if="group.location"> &mdash; {{ group.location }}</span>
                             &mdash; {{ group.charges.length }} <?= Yii::t('hipanel:finance', 'charge(s)') ?>

--- a/tests/playwright/e2e/manager/generate-on-demand-document.spec.ts
+++ b/tests/playwright/e2e/manager/generate-on-demand-document.spec.ts
@@ -49,8 +49,8 @@ test(
 
     await expect(page).toHaveTitle("Generate on-demand document");
     await expect(page.locator("select[name=\"PrepareOnDemandDocumentForm[type]\"]")).toBeVisible();
-    await expect(page.locator("input[name=\"PrepareOnDemandDocumentForm[month]\"]")).toBeVisible();
-    await expect(page.locator("button[type=submit]")).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Date" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Prepare document" })).toBeVisible();
 
     if (billId) {
       await deleteBill(page, billId);
@@ -72,8 +72,8 @@ test(
 
     await expect(page).toHaveTitle("Generate on-demand document");
     await expect(page.locator("select[name=\"PrepareOnDemandDocumentForm[type]\"]")).toBeVisible();
-    await expect(page.locator("input[name=\"PrepareOnDemandDocumentForm[month]\"]")).toBeVisible();
-    await expect(page.locator("button[type=submit]")).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Date" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Prepare document" })).toBeVisible();
 
     if (billId) {
       await deleteBill(page, billId);


### PR DESCRIPTION
…fix defaults

- Restructure generate-on-demand-document view into two labeled boxes: "Selected charges" (PHP-rendered) and "Charges for document generation" (Vue-rendered)
- Add wasPrepared flag to correctly show "no eligible charges" alert
- Highlight ineligible charge rows in orange; group headers reflect eligibility
- Strip HTML tags from charge descriptions in Vue template
- Fix date hint: "Leave blank to use today's date"
- Add Russian translations for all new UI strings
- Fix Playwright spec selectors for date field and prepare button
- Fix ChargeGridView to guard against lazy-loading targetObjectsSearch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved on-demand document preparation with clearer eligibility highlighting for selected charges.
  - Added statuses for prepared, saved, viewed, and preview documents.
  - Added support for selecting document types and displaying eligible or ineligible charges.
  - Added Russian translations for the new document-generation interface.

- **Bug Fixes**
  - Prevented errors when charge relationships are unavailable.
  - Sanitized charge descriptions before displaying them.
  - Clarified the empty eligibility state when no documents can be prepared.
  - Updated date guidance to default to today’s date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->