### PR TITLE
HQD-318: Charge PDF invoices enhancements and fixes

### DIFF
--- a/src/grid/ChargeGridView.php
+++ b/src/grid/ChargeGridView.php
@@ -249,7 +249,11 @@ class ChargeGridView extends BoxedGridView
                 'headerOptions' => ['class' => 'text-center', 'style' => 'width:1em'],
                 'contentOptions' => ['class' => 'text-center'],
                 'value' => static fn(Charge $model): string => !empty($model->included_in_documents)
-                    ? Html::tag('i', '', ['class' => 'fa fa-file-text-o text-info', 'title' => Yii::t('hipanel:finance', 'Included in document')])
+                    ? Html::a(
+                        Html::tag('i', '', ['class' => 'fa fa-file-text-o text-info']),
+                        ['@document/index', 'DocumentSearch[charge_ids]' => $model->id],
+                        ['title' => Yii::t('hipanel:finance', 'Included in document')]
+                    )
                     : '',
             ],
         ], $this->amountColumns());

--- a/src/grid/GroupedByServerChargesGridView.php
+++ b/src/grid/GroupedByServerChargesGridView.php
@@ -81,7 +81,7 @@ class GroupedByServerChargesGridView extends BillGridView
                 'columns' => array_filter([
                     Yii::$app->user->can('bill.update') ? 'checkbox' : null,
                     'type_label', 'name',
-                    'quantity', 'sum', 'sum_with_children', 'time', 'is_payed',
+                    'quantity', 'sum', 'sum_with_children', 'time', 'is_payed', 'included_in_documents',
                     [
                         'class' => DataColumn::class,
                         'format' => 'raw',


### PR DESCRIPTION
## Summary

- Add `included_in_documents` column to `ChargeGridView` — shows a clickable icon linking to the document index filtered by this charge
- Add `included_in_documents` to `GroupedByServerChargesGridView` column list

## Test plan

- [ ] View charges grid — verify `included_in_documents` column appears
- [ ] Click the icon for a charge that is included in a document — verify it opens the document index filtered to that charge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Document icons in the charges grid now link directly to filtered document results for the selected charge.
  * Grouped-by-server charge views now include the document inclusion indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->