### PR TITLE
HQD-330: load included_in_documents when fetching charges for bill view

### DIFF
--- a/src/controllers/BillController.php
+++ b/src/controllers/BillController.php
@@ -138,6 +138,7 @@ class BillController extends CrudController
                     $dataProvider->query->joinWith(['charges' => function (ChargeQuery $query) {
                         $query->withCommonObject();
                         $query->withLatestCommonObject();
+                        $query->withIncludedInDocuments();
                     }])->andWhere(['with_charges' => true]);
                 },
                 'data' => function (Action $action, array $data) {


### PR DESCRIPTION
Add `withIncludedInDocuments()` to the ChargeQuery in BillController view action so the `included_in_documents` field is populated and the document search link icon appears in the charge grid on `/finance/bill/view`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Bill views now display the latest shared details for related charges.
  * Related charges also include common object information and document inclusion status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->