### PR TITLE
HQD-331: always render note editable widget in price form row

### DIFF
--- a/src/views/price/formRow/simple.php
+++ b/src/views/price/formRow/simple.php
@@ -22,9 +22,9 @@ use yii\widgets\ActiveForm;
 
 // Generates a unique identifier for the note.
 // $model->id is null during creation (before the model is saved).
-// $model->object_id is consistent across the page.
-// $i is a unique index for distinguishing notes on the same page in case if $model->id is null.
-$notePk = $model->id . $model->object_id . $i;
+// or unique index for distinguishing notes on the same page in case if $model->id is null.
+$notePk = $model->id ?? mt_rand();
+
 ?>
 
 <?= Html::activeHiddenInput($model, "[$i]object_id", ['ref' => 'object_id']) ?>
@@ -33,12 +33,7 @@ $notePk = $model->id . $model->object_id . $i;
 <?= Html::activeHiddenInput($model, "[$i]type", ['ref' => 'type']) ?>
 <?= Html::activeHiddenInput($model, "[$i]class") ?>
 <?= Html::activeHiddenInput($model, "[$i]object", ['value' => $model->object->name ?? '']) ?>
-<?= Html::activeHiddenInput($model, "[$i]note", [
-    'data' => [
-        'attribute' => 'note',
-        'pk' => $notePk,
-    ],
-]) ?>
+<?= Html::activeHiddenInput($model, "[$i]note", ['data' => ['attribute' => 'note', 'pk' => $notePk]]) ?>
 
 <?= Html::activeHiddenInput($model, "[$i]quantity") ?>
 <?= Html::activeHiddenInput($model, "[$i]unit") ?>
@@ -67,25 +62,20 @@ $notePk = $model->id . $model->object_id . $i;
                 'model' => $model,
                 'field' => 'type',
             ]) ?>
-            <br/>
-            <?php if ($model->object_id) : ?>
-                <?= XEditable::widget([
-                    'model' => $model,
-                    'attribute' => 'note',
-                    'pluginOptions' => [
-                        'selector' => ".editable[data-pk={$notePk}][data-name=note]",
-                        'data-pk' => $notePk,
-                        'url' => new JsExpression(<<<"JS"
-                        function(params) {
-                            $(this).closest(".form-instance").parent().find("input[data-attribute=note]").val(params.value);
-                            
-                            return $.Deferred().resolve();
+            <?= XEditable::widget([
+                'model' => $model,
+                'attribute' => 'note',
+                'pluginOptions' => [
+                    'selector' => ".editable[data-pk=$notePk][data-name=note]",
+                    'data-pk' => $notePk,
+                    'url' => new JsExpression(<<<"JS"
+                        function (params) {
+                          $(this).closest(".form-instance").parent().find("input[data-attribute=note]").val(params.value);
+                          return $.Deferred();
                         }
-JS
-                    ),
+                    JS),
                 ],
-                ]) ?>
-            <?php endif ?>
+            ]) ?>
         </div>
     </div>
     <div class="col-md-4">


### PR DESCRIPTION
Previously the note-editable field was only shown when $model->object_id was set, which hid it for newly added rows before the object was chosen. Also, simplify the note pk generation to rely on mt_rand() instead of concatenating id/object_id/index.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved note handling in price forms by ensuring note editing is consistently available.
  - Stabilized note identification to prevent conflicts when working with unsaved or newly created entries.
  - Improved update behavior while note changes are being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->