### PR TITLE
HQD-345: add document_ids to ChargeSearch searchAttributes

### DIFF
--- a/src/models/ChargeSearch.php
+++ b/src/models/ChargeSearch.php
@@ -48,6 +48,7 @@ class ChargeSearch extends Charge
             'hide_child_charges',
             'requisite_id',
             'client_tags',
+            'document_ids',
         ]);
     }
 


### PR DESCRIPTION
## Summary

- Adds `document_ids` to `ChargeSearch::searchAttributes()` so the `ChargeSearch[document_ids]` filter parameter is accepted and passed through to the API query
- Required for the "All charges" link on the document view page to filter charges by document

## Test plan

- [ ] Open document view page, click "All charges" link — verify charge list is filtered to only charges belonging to that document