### PR TITLE
HQD-346: pass document_id in handleSubmit when replacing a single document

### DIFF
--- a/src/assets/FinanceDocumentsBox/src/composables/useDocumentGeneration.svelte.ts
+++ b/src/assets/FinanceDocumentsBox/src/composables/useDocumentGeneration.svelte.ts
@@ -84,6 +84,7 @@ export function useDocumentGeneration(
       type, period: period, client_id, id,
       ...(seller_bank_account_no != null ? { seller_bank_account_no } : {}),
       ...(client_bank_account_no != null ? { client_bank_account_no } : {}),
+      ...(affectedDocs.length === 1 ? { document_id: affectedDocs[0].id } : {}),
     })
       .then(rsp => {
         clearInterval(timer);


### PR DESCRIPTION
## Summary

- When the modal "Generate/Replace" action replaces exactly one existing document, its `document_id` is now passed to the API
- This allows the backend to find on-demand (`is_manual=true`) documents directly by ID — previously `findExistingGeneratedDocument` skipped them due to its `is_manual=0` filter, causing a new document to be created instead of the existing one being regenerated

## Test plan

- [ ] Open "Generate" modal for a type/period that has an existing on-demand document → confirm → verify the existing document is replaced (not a new one created)
- [ ] Open "Generate" modal for a regular monthly document — verify no regression (still replaces correctly)
- [ ] Multi-location documents (NL + FIN): no `document_id` is passed when `affectedDocs.length > 1` — verify both locations regenerate correctly