### PR TITLE
HQD-352: fix duplicated cart payment options for same-currency purse

### DIFF
--- a/src/widgets/CartCurrencyNegotiator.php
+++ b/src/widgets/CartCurrencyNegotiator.php
@@ -140,16 +140,24 @@ final class CartCurrencyNegotiator extends Widget
             return ExchangeRate::find()->select(['from', 'to', 'rate'])->all();
         }, 3600);
 
+        $cartCurrency = strtoupper($cartCurrency);
         $result = [];
-        foreach ($clientPursesCurrencies as $currency) {
+        foreach (array_unique($clientPursesCurrencies) as $currency) {
+            $currency = strtoupper($currency);
+            // Cart currency is already rendered by the initial renderCurrencyOptions() call in run(),
+            // so it must be skipped here to avoid rendering the same options block twice.
+            if ($currency === $cartCurrency || isset($result[$currency])) {
+                continue;
+            }
             foreach ($rates as $rate) {
-                if ($rate->from === strtoupper($currency) && $rate->to === strtoupper($cartCurrency)) {
-                    $result[] = $rate;
+                if ($rate->from === $currency && $rate->to === $cartCurrency) {
+                    $result[$currency] = $rate;
+                    break;
                 }
             }
         }
 
-        return $result;
+        return array_values($result);
     }
 
     public function getViewPath()


### PR DESCRIPTION
## Summary
- `CartCurrencyNegotiator::run()` renders the cart payment options block unconditionally for the cart currency, then loops over the client's convertible purse currencies and renders again for each.
- `convertibleCurrencies()` did not exclude the cart's own currency, so whenever a client purse currency matched the cart currency (e.g. AHnames single-currency setup, or the exchange-rates API returning a same-currency pair), the options block was rendered twice — visible as duplicated payment options in the cart.
- Fix: skip the cart currency and deduplicate by currency in `convertibleCurrencies()`.

## Test plan
- [ ] `php -l` passes on the changed file
- [ ] Manually verify the AHnames cart/select page no longer shows duplicated payment option blocks for a client whose purse currency matches the cart currency