### PR TITLE
HQD-395: bill.read fallback for currency exchange UI

### DIFF
--- a/src/views/bill/index.php
+++ b/src/views/bill/index.php
@@ -46,7 +46,8 @@ $this->params['subtitle'] = $subtitle . ' ' . ExchangeRatesLine::widget(['rates'
             <?= CreateBillWithSplitDropdownButton::widget() ?>
             <?= Html::a(Yii::t('hipanel:finance', 'Add internal transfer'), ['@bill/create-transfer'], ['class' => 'btn btn-sm btn-default']) ?>
         <?php endif ?>
-        <?php if (Yii::$app->user->can('bill.create-exchange')) : ?>
+        <?php $exchangePermission = !empty(Yii::$app->params['module.bill.skip.check.permission.exchange-create']) ? 'bill.read' : 'bill.create-exchange'; ?>
+        <?php if (Yii::$app->user->can($exchangePermission)) : ?>
             <?= Html::a(Yii::t('hipanel:finance', 'Currency exchange'), ['@bill/create-exchange'], ['class' => 'btn btn-sm btn-default']) ?>
         <?php endif ?>
         <?= BillImportDropdownButton::widget() ?>

--- a/src/widgets/CartCurrencyNegotiator.php
+++ b/src/widgets/CartCurrencyNegotiator.php
@@ -56,7 +56,8 @@ final class CartCurrencyNegotiator extends Widget
             $cartCurrency
         );
 
-        if (!Yii::$app->user->can('support')) {
+        $exchangePermission = !empty(Yii::$app->params['module.bill.skip.check.permission.exchange-create']) ? 'bill.read' : 'bill.create-exchange';
+        if (!Yii::$app->user->can('support') && Yii::$app->user->can($exchangePermission)) {
             // Prevent seller from exchanging own money to pay for client's services,
             // when client's tariff is in different currency.
             $convertibleCurrencies = $this->convertibleCurrencies(

--- a/src/widgets/ExchangeRatesLine.php
+++ b/src/widgets/ExchangeRatesLine.php
@@ -35,7 +35,8 @@ class ExchangeRatesLine extends Widget
 
     public function run()
     {
-        if (!Yii::$app->user->can('bill.create-exchange') || empty($this->rates)) {
+        $requiredPermission = !empty(Yii::$app->params['module.bill.skip.check.permission.exchange-create']) ? 'bill.read' : 'bill.create-exchange';
+        if (!Yii::$app->user->can($requiredPermission) || empty($this->rates)) {
             return '';
         }
 


### PR DESCRIPTION
## Summary
- hiapi-legacy's `billCreateExchange` now falls back to requiring `bill.read` instead of `bill.create-exchange` when `yii::getApp()->params['module.bill.skip.check.permission.exchange-create']` is set (the RBAC MR to grant `bill.create-exchange` to `role:client` was rejected).
- Mirror the same fallback here so regular clients who can actually complete an exchange also see the UI for it: the "Currency exchange" button (`views/bill/index.php`), the exchange rates line (`widgets/ExchangeRatesLine.php`), and the cart currency negotiator (`widgets/CartCurrencyNegotiator.php`).

Related: https://git.hiqdev.com/hiqdev/hiapi-legacy/-/merge_requests/1901

Jira: HQD-395